### PR TITLE
map a11y report to links

### DIFF
--- a/client/src/routes/(authenticated)/reports/$fileId/index.tsx
+++ b/client/src/routes/(authenticated)/reports/$fileId/index.tsx
@@ -4,6 +4,7 @@ import {
   type AccessibilityReportDetails,
   type AccessibilityReportJson,
 } from '@/queries/files.ts';
+import { RuleInfoLink } from '@/shared/accessibility/ruleInfoLink.tsx';
 import { ArrowDownTrayIcon } from '@heroicons/react/24/solid';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
@@ -416,7 +417,10 @@ function RouteComponent() {
                       <tr key={`${r.category}||${r.rule}||${idx}`}>
                         <td className="text-base-content">{r.category}</td>
                         <td>
-                          <div className="font-medium">{r.rule}</div>
+                          <div className="flex items-center gap-2">
+                            <div className="font-medium">{r.rule}</div>
+                            <RuleInfoLink rule={r.rule} />
+                          </div>
                           {r.description ? (
                             <div className="text-xs text-base-content/80">
                               {r.description}
@@ -466,7 +470,10 @@ function RouteComponent() {
                       <tr key={`${r.category}||${r.rule}||${idx}`}>
                         <td className="text-base-content">{r.category}</td>
                         <td>
-                          <div className="font-medium">{r.rule}</div>
+                          <div className="flex items-center gap-2">
+                            <div className="font-medium">{r.rule}</div>
+                            <RuleInfoLink rule={r.rule} />
+                          </div>
                           {r.description ? (
                             <div className="text-xs text-base-content/80">
                               {r.description}
@@ -531,7 +538,10 @@ function RouteComponent() {
                           {c.rows.map((r) => (
                             <tr key={`${r.category}||${r.rule}`}>
                               <td>
-                                <div className="font-medium">{r.rule}</div>
+                                <div className="flex items-center gap-2">
+                                  <div className="font-medium">{r.rule}</div>
+                                  <RuleInfoLink rule={r.rule} />
+                                </div>
                                 {r.description ? (
                                   <div className="text-xs text-base-content/80">
                                     {r.description}

--- a/client/src/shared/accessibility/ruleInfoLink.tsx
+++ b/client/src/shared/accessibility/ruleInfoLink.tsx
@@ -1,0 +1,127 @@
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+const ADOBE_ACCESSIBILITY_RULES_URL =
+  'https://helpx.adobe.com/acrobat/using/create-verify-pdf-accessibility.html';
+
+const ADOBE_ACCESSIBILITY_RULE_ANCHORS = [
+  'Perms',
+  'ImageOnlyPDF',
+  'TaggedPDF',
+  'LogicalRO',
+  'PrimeLang',
+  'DocTitle',
+  'Bookmarks',
+  'ColorContrast',
+  'TaggedCont',
+  'TaggedAnnots',
+  'TabOrder',
+  'CharEnc',
+  'Multimedia',
+  'FlickerRate',
+  'Scripts',
+  'TimedResponses',
+  'NavLinks',
+  'TaggedFormFields',
+  'FormFieldNames',
+  'FigAltText',
+  'NestedAltText',
+  'AltTextNoContent',
+  'HiddenAnnot',
+  'OtherAltText',
+  'TableRows',
+  'THTD',
+  'TableHeaders',
+  'RegularTable',
+  'TableSummary',
+  'ListItems',
+  'LblLBody',
+  'Headings',
+] as const;
+
+type AdobeAccessibilityRuleAnchor =
+  (typeof ADOBE_ACCESSIBILITY_RULE_ANCHORS)[number];
+
+function normalizeRuleKey(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^\da-z]+/g, '');
+}
+
+const ADOBE_ACCESSIBILITY_RULE_ANCHORS_BY_KEY = Object.fromEntries(
+  ADOBE_ACCESSIBILITY_RULE_ANCHORS.map((anchor) => [
+    normalizeRuleKey(anchor),
+    anchor,
+  ])
+) as Readonly<Record<string, AdobeAccessibilityRuleAnchor>>;
+
+const RULE_KEY_TO_ADOBE_ANCHOR: Readonly<
+  Record<string, AdobeAccessibilityRuleAnchor>
+> = {
+  accessibilitypermissionflag: 'Perms',
+  appropriatenesting: 'Headings',
+  associatedwithcontent: 'AltTextNoContent',
+  characterencoding: 'CharEnc',
+  fielddescriptions: 'FormFieldNames',
+  figuresalternatetext: 'FigAltText',
+  headers: 'TableHeaders',
+  hiddenannotation: 'HiddenAnnot',
+  hidesannotation: 'HiddenAnnot',
+  lblandlbody: 'LblLBody',
+  logicalreadingorder: 'LogicalRO',
+  navigationlinks: 'NavLinks',
+  nestedalternatetext: 'NestedAltText',
+  otherelementsalternatetext: 'OtherAltText',
+  permissions: 'Perms',
+  primarylanguage: 'PrimeLang',
+  regularity: 'RegularTable',
+  rows: 'TableRows',
+  screenflicker: 'FlickerRate',
+  summary: 'TableSummary',
+  taggedannotations: 'TaggedAnnots',
+  taggedcontent: 'TaggedCont',
+  taggedmultimedia: 'Multimedia',
+  thandtd: 'THTD',
+  title: 'DocTitle',
+};
+
+function ruleToAdobeAnchor(rule: string) {
+  const ruleKey = normalizeRuleKey(rule);
+  if (!ruleKey) {
+    return null;
+  }
+
+  return (
+    RULE_KEY_TO_ADOBE_ANCHOR[ruleKey] ??
+    ADOBE_ACCESSIBILITY_RULE_ANCHORS_BY_KEY[ruleKey] ??
+    null
+  );
+}
+
+export function adobeAccessibilityRuleHref(rule: string) {
+  const anchor = ruleToAdobeAnchor(rule);
+  if (!anchor) {
+    return ADOBE_ACCESSIBILITY_RULES_URL;
+  }
+  return `${ADOBE_ACCESSIBILITY_RULES_URL}#${encodeURIComponent(anchor)}`;
+}
+
+export type RuleInfoLinkProps = {
+  className?: string;
+  rule: string;
+};
+
+export function RuleInfoLink({ className, rule }: RuleInfoLinkProps) {
+  return (
+    <a
+      aria-label={`Open Adobe documentation for rule: ${rule}`}
+      className={`btn btn-ghost btn-xs btn-circle ${className ?? ''}`.trim()}
+      href={adobeAccessibilityRuleHref(rule)}
+      rel="noreferrer noopener"
+      target="_blank"
+      title="Open Adobe documentation for this rule"
+    >
+      <InformationCircleIcon className="h-4 w-4" />
+    </a>
+  );
+}

--- a/client/src/test/shared/accessibility/ruleInfoLink.test.ts
+++ b/client/src/test/shared/accessibility/ruleInfoLink.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { adobeAccessibilityRuleHref } from '@/shared/accessibility/ruleInfoLink.tsx';
+
+const BASE_URL =
+  'https://helpx.adobe.com/acrobat/using/create-verify-pdf-accessibility.html';
+
+describe('adobeAccessibilityRuleHref', () => {
+  it('maps known Adobe Accessibility Checker rules to anchors', () => {
+    const cases: Array<[rule: string, anchor: string]> = [
+      ['Accessibility permission flag', 'Perms'],
+      ['Appropriate nesting', 'Headings'],
+      ['Associated with content', 'AltTextNoContent'],
+      ['Bookmarks', 'Bookmarks'],
+      ['Character encoding', 'CharEnc'],
+      ['Color contrast', 'ColorContrast'],
+      ['Field descriptions', 'FormFieldNames'],
+      ['Figures alternate text', 'FigAltText'],
+      ['Headers', 'TableHeaders'],
+      ['Hides annotation', 'HiddenAnnot'],
+      ['Image-only PDF', 'ImageOnlyPDF'],
+      ['List items', 'ListItems'],
+      ['Lbl and LBody', 'LblLBody'],
+      ['Logical reading order', 'LogicalRO'],
+      ['Navigation links', 'NavLinks'],
+      ['Nested alternate text', 'NestedAltText'],
+      ['Other elements alternate text', 'OtherAltText'],
+      ['Permissions', 'Perms'],
+      ['Primary language', 'PrimeLang'],
+      ['Regularity', 'RegularTable'],
+      ['Rows', 'TableRows'],
+      ['Screen flicker', 'FlickerRate'],
+      ['Scripts', 'Scripts'],
+      ['Summary', 'TableSummary'],
+      ['TH and TD', 'THTD'],
+      ['Tab order', 'TabOrder'],
+      ['Tagged annotations', 'TaggedAnnots'],
+      ['Tagged content', 'TaggedCont'],
+      ['Tagged form fields', 'TaggedFormFields'],
+      ['Tagged multimedia', 'Multimedia'],
+      ['Tagged PDF', 'TaggedPDF'],
+      ['Timed responses', 'TimedResponses'],
+      ['Title', 'DocTitle'],
+    ];
+
+    for (const [rule, anchor] of cases) {
+      expect(adobeAccessibilityRuleHref(rule)).toBe(`${BASE_URL}#${anchor}`);
+    }
+  });
+
+  it('falls back to the base URL when a rule is unknown', () => {
+    expect(adobeAccessibilityRuleHref('Not a real rule')).toBe(BASE_URL);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rule cells throughout the reports interface now display interactive links to Adobe accessibility documentation, enabling users to quickly access detailed information about specific accessibility rules and best practices.

* **Tests**
  * Added comprehensive test coverage for the documentation linking functionality to ensure accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->