### PR TITLE
Enables vector figure alt text generation

### DIFF
--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using server.core.Remediate;
 using server.core.Remediate.AltText;
 using server.core.Remediate.Bookmarks;
+using server.core.Remediate.Rasterize;
 using server.core.Remediate.Title;
 
 namespace server.core.Ingest;
@@ -106,6 +107,8 @@ public static class IngestServiceCollectionExtensions
             {
                 services.AddSingleton<IPdfBookmarkService, NoopPdfBookmarkService>();
             }
+
+            services.AddSingleton<IPdfPageRasterizer, DocnetPdfPageRasterizer>();
             services.AddSingleton<IPdfRemediationProcessor, PdfRemediationProcessor>();
         }
         else

--- a/server.core/Remediate/Rasterize/BgraBitmapCropper.cs
+++ b/server.core/Remediate/Rasterize/BgraBitmapCropper.cs
@@ -1,0 +1,35 @@
+namespace server.core.Remediate.Rasterize;
+
+public static class BgraBitmapCropper
+{
+    public static BgraBitmap Crop(BgraBitmap source, IntRect rect)
+    {
+        if (!source.IsValid)
+        {
+            throw new ArgumentException("Source bitmap is invalid.", nameof(source));
+        }
+
+        if (rect.IsEmpty)
+        {
+            return new BgraBitmap(Array.Empty<byte>(), 0, 0, 0);
+        }
+
+        if (rect.X < 0 || rect.Y < 0 || rect.X + rect.Width > source.WidthPx || rect.Y + rect.Height > source.HeightPx)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rect), rect, "Crop rectangle must be within the source bitmap.");
+        }
+
+        var croppedStride = rect.Width * 4;
+        var cropped = new byte[croppedStride * rect.Height];
+
+        for (var row = 0; row < rect.Height; row++)
+        {
+            var srcOffset = ((rect.Y + row) * source.StrideBytes) + (rect.X * 4);
+            var dstOffset = row * croppedStride;
+            Buffer.BlockCopy(source.BgraBytes, srcOffset, cropped, dstOffset, croppedStride);
+        }
+
+        return new BgraBitmap(cropped, rect.Width, rect.Height, croppedStride);
+    }
+}
+

--- a/server.core/Remediate/Rasterize/DocnetPdfPageRasterizer.cs
+++ b/server.core/Remediate/Rasterize/DocnetPdfPageRasterizer.cs
@@ -1,0 +1,72 @@
+using Docnet.Core;
+using Docnet.Core.Converters;
+using Docnet.Core.Models;
+using Docnet.Core.Readers;
+
+namespace server.core.Remediate.Rasterize;
+
+public sealed class DocnetPdfPageRasterizer : IPdfPageRasterizer
+{
+    private readonly IDocLib _docLib;
+
+    public DocnetPdfPageRasterizer()
+    {
+        _docLib = DocLib.Instance;
+    }
+
+    public bool IsAvailable => true;
+
+    public IPdfRasterDocument OpenDocument(string pdfPath, int dpi)
+    {
+        if (string.IsNullOrWhiteSpace(pdfPath))
+        {
+            throw new ArgumentException("PDF path is required.", nameof(pdfPath));
+        }
+
+        if (dpi <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dpi), dpi, "DPI must be positive.");
+        }
+
+        var scaleFactor = dpi / 72.0;
+        var docReader = _docLib.GetDocReader(pdfPath, new PageDimensions(scaleFactor));
+        return new DocnetRasterDocument(docReader);
+    }
+
+    private sealed class DocnetRasterDocument : IPdfRasterDocument
+    {
+        private readonly IDocReader _docReader;
+        private readonly NaiveTransparencyRemover _transparencyRemover = new(255, 255, 255);
+
+        public DocnetRasterDocument(IDocReader docReader)
+        {
+            _docReader = docReader ?? throw new ArgumentNullException(nameof(docReader));
+        }
+
+        public void Dispose()
+        {
+            _docReader.Dispose();
+        }
+
+        public BgraBitmap RenderPage(int pageNumber1Based, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (pageNumber1Based <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pageNumber1Based), pageNumber1Based, "Page number must be 1-based and positive.");
+            }
+
+            var pageIndex = pageNumber1Based - 1;
+            using var pageReader = _docReader.GetPageReader(pageIndex);
+
+            var width = pageReader.GetPageWidth();
+            var height = pageReader.GetPageHeight();
+
+            // Docnet returns pixels in B-G-R-A order.
+            var bytes = pageReader.GetImage(_transparencyRemover);
+            var stride = width * 4;
+            return new BgraBitmap(bytes, width, height, stride);
+        }
+    }
+}

--- a/server.core/Remediate/Rasterize/IPdfPageRasterizer.cs
+++ b/server.core/Remediate/Rasterize/IPdfPageRasterizer.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace server.core.Remediate.Rasterize;
+
+public interface IPdfPageRasterizer
+{
+    bool IsAvailable { get; }
+
+    IPdfRasterDocument OpenDocument(string pdfPath, int dpi);
+}
+
+public interface IPdfRasterDocument : IDisposable
+{
+    BgraBitmap RenderPage(int pageNumber1Based, CancellationToken cancellationToken);
+}
+
+public sealed record BgraBitmap(byte[] BgraBytes, int WidthPx, int HeightPx, int StrideBytes)
+{
+    [MemberNotNullWhen(true, nameof(BgraBytes))]
+    public bool IsValid => BgraBytes is { Length: > 0 }
+                           && WidthPx > 0
+                           && HeightPx > 0
+                           && StrideBytes >= WidthPx * 4;
+}
+

--- a/server.core/Remediate/Rasterize/IntRect.cs
+++ b/server.core/Remediate/Rasterize/IntRect.cs
@@ -1,0 +1,7 @@
+namespace server.core.Remediate.Rasterize;
+
+public readonly record struct IntRect(int X, int Y, int Width, int Height)
+{
+    public bool IsEmpty => Width <= 0 || Height <= 0;
+}
+

--- a/server.core/Remediate/Rasterize/NoopPdfPageRasterizer.cs
+++ b/server.core/Remediate/Rasterize/NoopPdfPageRasterizer.cs
@@ -1,0 +1,29 @@
+namespace server.core.Remediate.Rasterize;
+
+public sealed class NoopPdfPageRasterizer : IPdfPageRasterizer
+{
+    public static NoopPdfPageRasterizer Instance { get; } = new();
+
+    private NoopPdfPageRasterizer()
+    {
+    }
+
+    public bool IsAvailable => false;
+
+    public IPdfRasterDocument OpenDocument(string pdfPath, int dpi) => new NoopPdfRasterDocument();
+
+    private sealed class NoopPdfRasterDocument : IPdfRasterDocument
+    {
+        public void Dispose()
+        {
+        }
+
+        public BgraBitmap RenderPage(int pageNumber1Based, CancellationToken cancellationToken)
+        {
+            _ = pageNumber1Based;
+            cancellationToken.ThrowIfCancellationRequested();
+            return new BgraBitmap(Array.Empty<byte>(), 0, 0, 0);
+        }
+    }
+}
+

--- a/server.core/Remediate/Rasterize/PngEncoder.cs
+++ b/server.core/Remediate/Rasterize/PngEncoder.cs
@@ -1,0 +1,122 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+using System.IO.Hashing;
+using System.Text;
+
+namespace server.core.Remediate.Rasterize;
+
+public static class PngEncoder
+{
+    private static ReadOnlySpan<byte> PngSignature => new byte[]
+    {
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+    };
+
+    public static byte[] EncodeBgra32(BgraBitmap bitmap)
+    {
+        if (!bitmap.IsValid)
+        {
+            throw new ArgumentException("Bitmap is invalid.", nameof(bitmap));
+        }
+
+        using var output = new MemoryStream(capacity: bitmap.WidthPx * bitmap.HeightPx);
+        output.Write(PngSignature);
+
+        Span<byte> ihdr = stackalloc byte[13];
+        BinaryPrimitives.WriteUInt32BigEndian(ihdr, (uint)bitmap.WidthPx);
+        BinaryPrimitives.WriteUInt32BigEndian(ihdr[4..], (uint)bitmap.HeightPx);
+        ihdr[8] = 8; // bit depth
+        ihdr[9] = 6; // color type: RGBA
+        ihdr[10] = 0; // compression
+        ihdr[11] = 0; // filter
+        ihdr[12] = 0; // interlace
+        WriteChunk(output, "IHDR", ihdr);
+
+        var rgbaScanlines = BuildRgbaScanlines(bitmap);
+        var compressed = CompressZlib(rgbaScanlines);
+        WriteChunk(output, "IDAT", compressed);
+
+        WriteChunk(output, "IEND", ReadOnlySpan<byte>.Empty);
+        return output.ToArray();
+    }
+
+    private static byte[] BuildRgbaScanlines(BgraBitmap bitmap)
+    {
+        var rowBytes = bitmap.WidthPx * 4;
+        var scanlineBytes = 1 + rowBytes; // filter byte + pixels
+        var raw = new byte[bitmap.HeightPx * scanlineBytes];
+
+        for (var y = 0; y < bitmap.HeightPx; y++)
+        {
+            var srcRowOffset = y * bitmap.StrideBytes;
+            var dstRowOffset = y * scanlineBytes;
+
+            raw[dstRowOffset] = 0; // filter type: None
+
+            var dst = raw.AsSpan(dstRowOffset + 1, rowBytes);
+            var src = bitmap.BgraBytes.AsSpan(srcRowOffset, rowBytes);
+
+            // Convert BGRA -> RGBA
+            for (var i = 0; i < rowBytes; i += 4)
+            {
+                dst[i + 0] = src[i + 2]; // R
+                dst[i + 1] = src[i + 1]; // G
+                dst[i + 2] = src[i + 0]; // B
+                dst[i + 3] = src[i + 3]; // A
+            }
+        }
+
+        return raw;
+    }
+
+    private static byte[] CompressZlib(byte[] raw)
+    {
+        using var ms = new MemoryStream(capacity: raw.Length / 2);
+        using (var z = new ZLibStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            z.Write(raw, 0, raw.Length);
+        }
+
+        return ms.ToArray();
+    }
+
+    private static void WriteChunk(Stream output, string type, ReadOnlySpan<byte> data)
+    {
+        if (type.Length != 4)
+        {
+            throw new ArgumentException("PNG chunk type must be 4 characters.", nameof(type));
+        }
+
+        Span<byte> lenBytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(lenBytes, (uint)data.Length);
+        output.Write(lenBytes);
+
+        var typeBytes = Encoding.ASCII.GetBytes(type);
+        output.Write(typeBytes, 0, typeBytes.Length);
+
+        if (!data.IsEmpty)
+        {
+            output.Write(data);
+        }
+
+        Span<byte> crcBytes = stackalloc byte[4];
+        var crc = ComputeCrc(typeBytes, data);
+        BinaryPrimitives.WriteUInt32BigEndian(crcBytes, crc);
+        output.Write(crcBytes);
+    }
+
+    private static uint ComputeCrc(byte[] typeBytes, ReadOnlySpan<byte> data)
+    {
+        var crc32 = new Crc32();
+        crc32.Append(typeBytes);
+        if (!data.IsEmpty)
+        {
+            crc32.Append(data);
+        }
+
+        Span<byte> hash = stackalloc byte[4];
+        crc32.GetCurrentHash(hash);
+        return BinaryPrimitives.ReadUInt32BigEndian(hash);
+    }
+}
+

--- a/server.core/server.core.csproj
+++ b/server.core/server.core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Adobe.PDFServicesSDK" Version="4.3.1" />
+    <PackageReference Include="Docnet.Core" Version="2.6.0" />
     <PackageReference Include="itext" Version="9.4.0" />
     <PackageReference Include="itext.bouncy-castle-adapter" Version="9.4.0" />
     <PackageReference Include="OpenAI" Version="2.7.0" />

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorLayoutTableDemotionTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorLayoutTableDemotionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using server.core.Remediate;
 using server.core.Remediate.AltText;
+using server.core.Remediate.Rasterize;
 using server.core.Remediate.Title;
 
 namespace server.tests.Integration.Remediate;
@@ -41,6 +42,7 @@ public sealed class PdfRemediationProcessorLayoutTableDemotionTests
             var sut = new PdfRemediationProcessor(
                 new ThrowingAltTextService(),
                 new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
                 new ThrowingPdfTitleService(),
                 opts,
                 NullLogger<PdfRemediationProcessor>.Instance);
@@ -160,4 +162,3 @@ public sealed class PdfRemediationProcessorLayoutTableDemotionTests
             throw new InvalidOperationException("Title service should not be called for layout table demotion tests.");
     }
 }
-

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorVectorFigureAltTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorVectorFigureAltTests.cs
@@ -1,0 +1,221 @@
+using FluentAssertions;
+using iText.Kernel.Pdf;
+using Microsoft.Extensions.Logging.Abstractions;
+using server.core.Remediate;
+using server.core.Remediate.AltText;
+using server.core.Remediate.Rasterize;
+
+namespace server.tests.Integration.Remediate;
+
+public sealed class PdfRemediationProcessorVectorFigureAltTests
+{
+    [Fact]
+    public async Task ProcessAsync_TaggedHasPlaceholderAlt_ReplacesPlaceholderAltForVectorFigures()
+    {
+        var repoRoot = FindRepoRoot();
+        var inputPdfPath = Path.Combine(repoRoot, "tests", "server.tests", "Fixtures", "pdfs", "tagged-bad-alt.pdf");
+        File.Exists(inputPdfPath).Should().BeTrue($"fixture should exist at {inputPdfPath}");
+
+        var inputPlaceholderCount = 0;
+        using (var inputPdf = new PdfDocument(new PdfReader(inputPdfPath)))
+        {
+            inputPdf.IsTagged().Should().BeTrue("fixture should be tagged");
+            var inputFigures = ListStructElementsByRole(inputPdf, PdfName.Figure);
+            inputFigures.Count.Should().BeGreaterThan(0);
+            inputPlaceholderCount = inputFigures.Count(f => IsPlaceholderAlt(f));
+            inputPlaceholderCount.Should().BeGreaterThan(0, "fixture should contain placeholder alt text");
+        }
+
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-vector-alt-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+
+            var altText = new FakeAltTextService();
+            var sut = new PdfRemediationProcessor(
+                altText,
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                new FakePdfPageRasterizer(),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
+            var outputPlaceholderCount = outputFigures.Count(f => IsPlaceholderAlt(f));
+
+            outputPlaceholderCount.Should().BeLessThan(inputPlaceholderCount, "vector figure remediation should reduce placeholder alt text");
+            altText.ImageCalls.Should().BeGreaterThan(0, "vector figure remediation should call the alt text service at least once");
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    private sealed class FakeAltTextService : IAltTextService
+    {
+        public int ImageCalls { get; private set; }
+
+        public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            ImageCalls++;
+            return Task.FromResult("generated alt text");
+        }
+
+        public Task<string> GetAltTextForLinkAsync(LinkAltTextRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult("generated link alt");
+        }
+
+        public string GetFallbackAltTextForImage() => "alt text for image";
+
+        public string GetFallbackAltTextForLink() => "alt text for link";
+    }
+
+    private sealed class FakePdfTitleService : server.core.Remediate.Title.IPdfTitleService
+    {
+        public Task<string> GenerateTitleAsync(server.core.Remediate.Title.PdfTitleRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult("fake title");
+        }
+    }
+
+    private sealed class FakePdfPageRasterizer : IPdfPageRasterizer
+    {
+        private static readonly BgraBitmap BlankPage = CreateBlankPage(widthPx: 200, heightPx: 200);
+
+        public bool IsAvailable => true;
+
+        public IPdfRasterDocument OpenDocument(string pdfPath, int dpi)
+        {
+            _ = pdfPath;
+            _ = dpi;
+            return new Doc();
+        }
+
+        private sealed class Doc : IPdfRasterDocument
+        {
+            public void Dispose()
+            {
+            }
+
+            public BgraBitmap RenderPage(int pageNumber1Based, CancellationToken cancellationToken)
+            {
+                _ = pageNumber1Based;
+                cancellationToken.ThrowIfCancellationRequested();
+                return BlankPage;
+            }
+        }
+
+        private static BgraBitmap CreateBlankPage(int widthPx, int heightPx)
+        {
+            var stride = widthPx * 4;
+            var bytes = new byte[stride * heightPx];
+            for (var i = 0; i < bytes.Length; i += 4)
+            {
+                bytes[i + 0] = 255; // B
+                bytes[i + 1] = 255; // G
+                bytes[i + 2] = 255; // R
+                bytes[i + 3] = 255; // A
+            }
+
+            return new BgraBitmap(bytes, widthPx, heightPx, stride);
+        }
+    }
+
+    private static bool IsPlaceholderAlt(PdfDictionary structElem)
+    {
+        var alt = structElem.GetAsString(PdfName.Alt)?.ToUnicodeString() ?? string.Empty;
+        return string.Equals(alt.Trim(), "alt text for image", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "app.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        if (dir is null)
+        {
+            throw new DirectoryNotFoundException("Unable to locate repo root (missing app.sln).");
+        }
+
+        return dir.FullName;
+    }
+
+    private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
+    {
+        var results = new List<PdfDictionary>();
+
+        var catalogDict = pdf.GetCatalog().GetPdfObject();
+        var structTreeRootDict = catalogDict.GetAsDictionary(PdfName.StructTreeRoot);
+        if (structTreeRootDict is null)
+        {
+            return results;
+        }
+
+        var rootKids = structTreeRootDict.Get(PdfName.K);
+        if (rootKids is null)
+        {
+            return results;
+        }
+
+        Traverse(rootKids, role, results);
+        return results;
+    }
+
+    private static void Traverse(PdfObject node, PdfName role, List<PdfDictionary> results)
+    {
+        node = Dereference(node);
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                Traverse(item, role, results);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        var s = dict.GetAsName(PdfName.S);
+        if (role.Equals(s))
+        {
+            results.Add(dict);
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            Traverse(kids, role, results);
+        }
+    }
+
+    private static PdfObject Dereference(PdfObject obj)
+        => obj is PdfIndirectReference reference ? reference.GetRefersTo(true) : obj;
+}
+

--- a/tools/remediate.diagnostics.runner/Program.cs
+++ b/tools/remediate.diagnostics.runner/Program.cs
@@ -1,0 +1,879 @@
+using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Data;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using iText.Kernel.Pdf.Xobject;
+
+internal static class Program
+{
+    public static int Main(string[] args)
+    {
+        var (inputPath, extractImagesDir) = ParseArgs(args);
+        if (inputPath is null)
+        {
+            PrintUsage();
+            return 2;
+        }
+
+        if (!File.Exists(inputPath))
+        {
+            Console.Error.WriteLine($"Input PDF not found: {inputPath}");
+            return 2;
+        }
+
+        using var pdf = new PdfDocument(new PdfReader(inputPath));
+
+        Console.WriteLine($"Input: {inputPath}");
+        Console.WriteLine($"Pages: {pdf.GetNumberOfPages()}");
+        Console.WriteLine($"Tagged: {pdf.IsTagged()}");
+
+        var catalog = pdf.GetCatalog().GetPdfObject();
+        var structTreeRoot = catalog.GetAsDictionary(PdfName.StructTreeRoot);
+        Console.WriteLine($"StructTreeRoot: {(structTreeRoot is null ? "no" : "yes")}");
+        if (structTreeRoot is not null)
+        {
+            var parentTree = structTreeRoot.Get(PdfName.ParentTree);
+            Console.WriteLine($"ParentTree: {(parentTree is null || parentTree is PdfNull ? "no" : "yes")}");
+        }
+
+        var pageObjNumToPageNumber = BuildPageObjectNumberToPageNumberMap(pdf);
+        var figures = ListStructElementsByRole(pdf, PdfName.Figure);
+        var figureAnalysis = AnalyzeFigures(figures, pageObjNumToPageNumber);
+
+        Console.WriteLine();
+        Console.WriteLine("Tag tree:");
+        Console.WriteLine($"- Figures: {figures.Count}");
+        Console.WriteLine($"- Figures with non-empty /Alt: {figureAnalysis.WithAlt}");
+        Console.WriteLine($"- Figures missing /Alt: {figureAnalysis.MissingAlt}");
+        Console.WriteLine($"- Figures with fallback /Alt (\"alt text for image\"): {figureAnalysis.FallbackAltCount}");
+        Console.WriteLine($"- Figures with any MCID references: {figureAnalysis.WithMcidRefs}");
+        Console.WriteLine($"- Figures with any OBJR references: {figureAnalysis.WithObjRefs}");
+        Console.WriteLine($"- Figures with NO MCID/OBJR references: {figureAnalysis.WithNoContentRefs}");
+        Console.WriteLine($"- Figures with resolvable page association: {figureAnalysis.PageResolved}");
+
+        var imageOccurrences = new List<ImageOccurrence>();
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            imageOccurrences.AddRange(ListImageOccurrences(pdf.GetPage(pageNumber), pageNumber));
+        }
+
+        var distinctImageXObjects = CountImageXObjects(pdf);
+
+        var figureIndex = BuildStructTreeIndexForRole(figures, pageObjNumToPageNumber);
+        var matchStats = MatchImageOccurrencesToFigures(imageOccurrences, figureIndex);
+        var figureMcids = figureIndex.StructElemsByMcid.Keys.ToHashSet();
+        var imageMcids = imageOccurrences
+            .Where(o => o.Mcid >= 0)
+            .Select(o => (o.PageNumber, o.Mcid))
+            .ToHashSet();
+        var figureMcidsWithoutImages = figureMcids.Except(imageMcids).Count();
+
+        Console.WriteLine();
+        Console.WriteLine("Rendered images:");
+        Console.WriteLine($"- Image render occurrences (content stream): {imageOccurrences.Count}");
+        Console.WriteLine($"- Distinct image XObjects (resources): {distinctImageXObjects}");
+        Console.WriteLine($"- Unique /Figure MCIDs referenced: {figureMcids.Count}");
+        Console.WriteLine($"- Unique MCIDs with image render occurrences: {imageMcids.Count}");
+        Console.WriteLine($"- /Figure MCIDs with no image render occurrence: {figureMcidsWithoutImages}");
+        Console.WriteLine($"- Occurrences with MCID >= 0: {matchStats.OccurrencesWithMcid}");
+        Console.WriteLine($"- Occurrences with indirect image ref: {matchStats.OccurrencesWithObjRef}");
+        Console.WriteLine($"- Occurrences matched to at least one /Figure: {matchStats.MatchedOccurrences}");
+        Console.WriteLine($"- Occurrences NOT matched to a /Figure: {matchStats.UnmatchedOccurrences}");
+        Console.WriteLine($"- Distinct matched /Figure elements: {matchStats.DistinctMatchedFigures}");
+
+        if (extractImagesDir is not null)
+        {
+            Console.WriteLine();
+            ExtractImages(imageOccurrences, extractImagesDir);
+        }
+
+        return 0;
+    }
+
+    private static void PrintUsage()
+    {
+        Console.Error.WriteLine("Usage:");
+        Console.Error.WriteLine("  dotnet run --project tools/remediate.diagnostics.runner -- --input <path> [--extract-images <dir>]");
+    }
+
+    private static (string? InputPath, string? ExtractImagesDir) ParseArgs(string[] args)
+    {
+        string? inputPath = null;
+        string? extractImagesDir = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if ((arg is "--input" or "-i") && i + 1 < args.Length)
+            {
+                inputPath = args[++i];
+                continue;
+            }
+
+            if (arg is "--extract-images" && i + 1 < args.Length)
+            {
+                extractImagesDir = args[++i];
+                continue;
+            }
+        }
+
+        return (inputPath, extractImagesDir);
+    }
+
+    private sealed record FigureAnalysis(
+        int WithAlt,
+        int MissingAlt,
+        int FallbackAltCount,
+        int WithMcidRefs,
+        int WithObjRefs,
+        int WithNoContentRefs,
+        int PageResolved);
+
+    private static FigureAnalysis AnalyzeFigures(IReadOnlyList<PdfDictionary> figures, Dictionary<int, int> pageObjNumToPageNumber)
+    {
+        var withAlt = 0;
+        var missingAlt = 0;
+        var fallbackAlt = 0;
+        var withMcidRefs = 0;
+        var withObjRefs = 0;
+        var withNoRefs = 0;
+        var pageResolved = 0;
+
+        foreach (var figure in figures)
+        {
+            var alt = figure.GetAsString(PdfName.Alt)?.ToUnicodeString();
+            if (string.IsNullOrWhiteSpace(alt))
+            {
+                missingAlt++;
+            }
+            else
+            {
+                withAlt++;
+                if (string.Equals(alt.Trim(), "alt text for image", StringComparison.OrdinalIgnoreCase))
+                {
+                    fallbackAlt++;
+                }
+            }
+
+            var refs = AnalyzeFigureContentRefs(figure);
+            if (refs.HasMcidRef)
+            {
+                withMcidRefs++;
+            }
+
+            if (refs.HasObjRef)
+            {
+                withObjRefs++;
+            }
+
+            if (!refs.HasMcidRef && !refs.HasObjRef)
+            {
+                withNoRefs++;
+            }
+
+            if (TryResolveStructElemPageNumber(figure, pageObjNumToPageNumber) is not null)
+            {
+                pageResolved++;
+            }
+        }
+
+        return new FigureAnalysis(
+            WithAlt: withAlt,
+            MissingAlt: missingAlt,
+            FallbackAltCount: fallbackAlt,
+            WithMcidRefs: withMcidRefs,
+            WithObjRefs: withObjRefs,
+            WithNoContentRefs: withNoRefs,
+            PageResolved: pageResolved);
+    }
+
+    private sealed record FigureContentRefs(bool HasMcidRef, bool HasObjRef);
+
+    private static FigureContentRefs AnalyzeFigureContentRefs(PdfDictionary figure)
+    {
+        var hasMcid = false;
+        var hasObj = false;
+
+        var kids = figure.Get(PdfName.K);
+        if (kids is null || kids is PdfNull)
+        {
+            return new FigureContentRefs(HasMcidRef: false, HasObjRef: false);
+        }
+
+        const int maxNodesToScan = 20_000;
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var stack = new Stack<PdfObject>();
+        stack.Push(kids);
+
+        var scanned = 0;
+        while (stack.Count > 0 && scanned < maxNodesToScan)
+        {
+            var node = stack.Pop();
+            node = Dereference(node, visited);
+            scanned++;
+
+            if (node is PdfNull)
+            {
+                continue;
+            }
+
+            if (node is PdfArray array)
+            {
+                foreach (var item in array)
+                {
+                    stack.Push(item);
+                }
+
+                continue;
+            }
+
+            if (node is PdfNumber)
+            {
+                hasMcid = true;
+                continue;
+            }
+
+            if (node is not PdfDictionary dict)
+            {
+                continue;
+            }
+
+            if (dict.GetAsNumber(PdfName.MCID) is not null)
+            {
+                hasMcid = true;
+            }
+
+            if (dict.Get(PdfName.Obj) is not null)
+            {
+                hasObj = true;
+            }
+
+            if (hasMcid && hasObj)
+            {
+                break;
+            }
+
+            var nestedKids = dict.Get(PdfName.K);
+            if (nestedKids is not null && nestedKids is not PdfNull)
+            {
+                stack.Push(nestedKids);
+            }
+        }
+
+        return new FigureContentRefs(HasMcidRef: hasMcid, HasObjRef: hasObj);
+    }
+
+    private sealed record ImageOccurrence(
+        int PageNumber,
+        int Mcid,
+        PdfImageXObject Image,
+        PdfIndirectReference? ImageRef,
+        int WidthPx,
+        int HeightPx);
+
+    private static IReadOnlyList<ImageOccurrence> ListImageOccurrences(PdfPage page, int pageNumber)
+    {
+        var listener = new ImageOccurrenceListener(pageNumber);
+        new PdfCanvasProcessor(listener).ProcessPageContent(page);
+        return listener.GetOccurrences();
+    }
+
+    private sealed class ImageOccurrenceListener : IEventListener
+    {
+        private readonly List<PendingImage> _pending = new();
+        private readonly int _pageNumber;
+
+        public ImageOccurrenceListener(int pageNumber)
+        {
+            _pageNumber = pageNumber;
+        }
+
+        public void EventOccurred(IEventData data, EventType type)
+        {
+            if (type != EventType.RENDER_IMAGE || data is not ImageRenderInfo imageRenderInfo)
+            {
+                return;
+            }
+
+            var image = imageRenderInfo.GetImage();
+            var imageRef = image.GetPdfObject().GetIndirectReference();
+
+            var imageDict = image.GetPdfObject();
+            var width = imageDict.GetAsNumber(PdfName.Width)?.IntValue() ?? 0;
+            var height = imageDict.GetAsNumber(PdfName.Height)?.IntValue() ?? 0;
+
+            _pending.Add(new PendingImage(imageRenderInfo.GetMcid(), image, imageRef, width, height));
+        }
+
+        public ICollection<EventType> GetSupportedEvents() => new[] { EventType.RENDER_IMAGE };
+
+        public IReadOnlyList<ImageOccurrence> GetOccurrences()
+            => _pending
+                .Select(p =>
+                    new ImageOccurrence(
+                        _pageNumber,
+                        p.Mcid,
+                        p.Image,
+                        p.ImageRef,
+                        p.WidthPx,
+                        p.HeightPx))
+                .ToArray();
+
+        private sealed record PendingImage(int Mcid, PdfImageXObject Image, PdfIndirectReference? ImageRef, int WidthPx, int HeightPx);
+    }
+
+    private sealed record StructTreeIndex(
+        Dictionary<(int pageNumber, int mcid), List<PdfDictionary>> StructElemsByMcid,
+        Dictionary<(int pageNumber, int objNum, int genNum), List<PdfDictionary>> StructElemsByObjRef);
+
+    private static StructTreeIndex BuildStructTreeIndexForRole(
+        IReadOnlyList<PdfDictionary> figures,
+        Dictionary<int, int> pageObjNumToPageNumber)
+    {
+        var byMcid = new Dictionary<(int pageNumber, int mcid), List<PdfDictionary>>();
+        var byObjRef = new Dictionary<(int pageNumber, int objNum, int genNum), List<PdfDictionary>>();
+
+        foreach (var figure in figures)
+        {
+            IndexStructElemContent(figure, pageObjNumToPageNumber, byMcid, byObjRef);
+        }
+
+        return new StructTreeIndex(byMcid, byObjRef);
+    }
+
+    private static void IndexStructElemContent(
+        PdfDictionary structElem,
+        Dictionary<int, int> pageObjNumToPageNumber,
+        Dictionary<(int pageNumber, int mcid), List<PdfDictionary>> structElemsByMcid,
+        Dictionary<(int pageNumber, int objNum, int genNum), List<PdfDictionary>> structElemsByObjRef)
+    {
+        var defaultPageDict = structElem.GetAsDictionary(PdfName.Pg);
+        var kids = structElem.Get(PdfName.K);
+        if (kids is null || kids is PdfNull)
+        {
+            return;
+        }
+
+        const int maxNodesToScan = 200_000;
+        var nodesScanned = 0;
+
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var stack = new Stack<(PdfObject Node, PdfDictionary? InheritedPageDict)>();
+        stack.Push((kids, defaultPageDict));
+
+        while (stack.Count > 0 && nodesScanned < maxNodesToScan)
+        {
+            var (node, inheritedPageDict) = stack.Pop();
+            node = Dereference(node, visited);
+            nodesScanned++;
+
+            if (node is PdfNull)
+            {
+                continue;
+            }
+
+            if (node is PdfArray array)
+            {
+                foreach (var item in array)
+                {
+                    stack.Push((item, inheritedPageDict));
+                }
+
+                continue;
+            }
+
+            if (node is PdfNumber num)
+            {
+                var pageNumber = TryResolvePageNumber(inheritedPageDict, pageObjNumToPageNumber);
+                if (pageNumber is not null)
+                {
+                    AddMapping(structElemsByMcid, (pageNumber.Value, num.IntValue()), structElem);
+                }
+
+                continue;
+            }
+
+            if (node is not PdfDictionary dict)
+            {
+                continue;
+            }
+
+            // Nested struct elem: recurse into its kids, but index mappings to the parent figure.
+            if (dict.ContainsKey(PdfName.S))
+            {
+                var nestedPageDict = dict.GetAsDictionary(PdfName.Pg) ?? inheritedPageDict;
+                var nestedKids = dict.Get(PdfName.K);
+                if (nestedKids is not null && nestedKids is not PdfNull)
+                {
+                    stack.Push((nestedKids, nestedPageDict));
+                }
+
+                continue;
+            }
+
+            var pageDict = dict.GetAsDictionary(PdfName.Pg) ?? inheritedPageDict;
+
+            var mcidNum = dict.GetAsNumber(PdfName.MCID);
+            if (mcidNum is not null)
+            {
+                var pageNumber = TryResolvePageNumber(pageDict, pageObjNumToPageNumber);
+                if (pageNumber is not null)
+                {
+                    AddMapping(structElemsByMcid, (pageNumber.Value, mcidNum.IntValue()), structElem);
+                }
+            }
+
+            var obj = dict.Get(PdfName.Obj);
+            if (obj is not null)
+            {
+                var objRef = obj.GetIndirectReference() ?? (obj as PdfIndirectReference);
+                if (objRef is not null)
+                {
+                    var pageNumber = TryResolvePageNumber(pageDict, pageObjNumToPageNumber);
+                    if (pageNumber is not null)
+                    {
+                        AddMapping(structElemsByObjRef, (pageNumber.Value, objRef.GetObjNumber(), objRef.GetGenNumber()), structElem);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void AddMapping<TKey>(Dictionary<TKey, List<PdfDictionary>> map, TKey key, PdfDictionary structElem)
+        where TKey : notnull
+    {
+        if (!map.TryGetValue(key, out var list))
+        {
+            list = new List<PdfDictionary>(capacity: 1);
+            map[key] = list;
+        }
+
+        if (!list.Contains(structElem))
+        {
+            list.Add(structElem);
+        }
+    }
+
+    private sealed record MatchStats(
+        int OccurrencesWithMcid,
+        int OccurrencesWithObjRef,
+        int MatchedOccurrences,
+        int UnmatchedOccurrences,
+        int DistinctMatchedFigures);
+
+    private static MatchStats MatchImageOccurrencesToFigures(IReadOnlyList<ImageOccurrence> occurrences, StructTreeIndex index)
+    {
+        var occurrencesWithMcid = 0;
+        var occurrencesWithObjRef = 0;
+        var matched = 0;
+        var unmatched = 0;
+
+        var matchedFigures = new HashSet<(int objNum, int genNum)>();
+
+        foreach (var occ in occurrences)
+        {
+            if (occ.Mcid >= 0)
+            {
+                occurrencesWithMcid++;
+            }
+
+            if (occ.ImageRef is not null)
+            {
+                occurrencesWithObjRef++;
+            }
+
+            var figures = ResolveFigures(index, occ.PageNumber, occ.Mcid, occ.ImageRef);
+            if (figures.Count == 0)
+            {
+                unmatched++;
+                continue;
+            }
+
+            matched++;
+            foreach (var figure in figures)
+            {
+                var figureRef = figure.GetIndirectReference();
+                if (figureRef is not null)
+                {
+                    matchedFigures.Add((figureRef.GetObjNumber(), figureRef.GetGenNumber()));
+                }
+            }
+        }
+
+        return new MatchStats(
+            OccurrencesWithMcid: occurrencesWithMcid,
+            OccurrencesWithObjRef: occurrencesWithObjRef,
+            MatchedOccurrences: matched,
+            UnmatchedOccurrences: unmatched,
+            DistinctMatchedFigures: matchedFigures.Count);
+    }
+
+    private static IReadOnlyList<PdfDictionary> ResolveFigures(
+        StructTreeIndex index,
+        int pageNumber,
+        int mcid,
+        PdfIndirectReference? objRef)
+    {
+        if (objRef is not null
+            && index.StructElemsByObjRef.TryGetValue((pageNumber, objRef.GetObjNumber(), objRef.GetGenNumber()), out var byObj))
+        {
+            return byObj;
+        }
+
+        if (mcid >= 0 && index.StructElemsByMcid.TryGetValue((pageNumber, mcid), out var byMcid))
+        {
+            return byMcid;
+        }
+
+        return Array.Empty<PdfDictionary>();
+    }
+
+    private static IReadOnlyList<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
+    {
+        var catalog = pdf.GetCatalog().GetPdfObject();
+        var structTreeRootDict = catalog.GetAsDictionary(PdfName.StructTreeRoot);
+        if (structTreeRootDict is null)
+        {
+            return Array.Empty<PdfDictionary>();
+        }
+
+        var rootKids = structTreeRootDict.Get(PdfName.K);
+        if (rootKids is null || rootKids is PdfNull)
+        {
+            return Array.Empty<PdfDictionary>();
+        }
+
+        const int maxNodesToScan = 200_000;
+        var nodesScanned = 0;
+
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var stack = new Stack<PdfObject>();
+        stack.Push(rootKids);
+
+        var results = new List<PdfDictionary>();
+
+        while (stack.Count > 0 && nodesScanned < maxNodesToScan)
+        {
+            var node = stack.Pop();
+            node = Dereference(node, visited);
+            nodesScanned++;
+
+            if (node is PdfNull)
+            {
+                continue;
+            }
+
+            if (node is PdfArray array)
+            {
+                foreach (var item in array)
+                {
+                    stack.Push(item);
+                }
+
+                continue;
+            }
+
+            if (node is not PdfDictionary dict)
+            {
+                continue;
+            }
+
+            var s = dict.GetAsName(PdfName.S);
+            if (role.Equals(s))
+            {
+                results.Add(dict);
+            }
+
+            var kids = dict.Get(PdfName.K);
+            if (kids is not null && kids is not PdfNull)
+            {
+                stack.Push(kids);
+            }
+        }
+
+        return results;
+    }
+
+    private static Dictionary<int, int> BuildPageObjectNumberToPageNumberMap(PdfDocument pdf)
+    {
+        var map = new Dictionary<int, int>();
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            var pageRef = pdf.GetPage(pageNumber).GetPdfObject().GetIndirectReference();
+            if (pageRef is null)
+            {
+                continue;
+            }
+
+            map[pageRef.GetObjNumber()] = pageNumber;
+        }
+
+        return map;
+    }
+
+    private static int? TryResolveStructElemPageNumber(PdfDictionary structElem, Dictionary<int, int> pageObjNumToPageNumber)
+    {
+        var direct = TryResolvePageNumber(structElem.GetAsDictionary(PdfName.Pg), pageObjNumToPageNumber);
+        if (direct is not null)
+        {
+            return direct;
+        }
+
+        var kids = structElem.Get(PdfName.K);
+        if (kids is null || kids is PdfNull)
+        {
+            return null;
+        }
+
+        const int maxNodesToScan = 20_000;
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var stack = new Stack<PdfObject>();
+        stack.Push(kids);
+
+        var scanned = 0;
+        while (stack.Count > 0 && scanned < maxNodesToScan)
+        {
+            var node = stack.Pop();
+            node = Dereference(node, visited);
+            scanned++;
+
+            if (node is PdfNull)
+            {
+                continue;
+            }
+
+            if (node is PdfArray array)
+            {
+                foreach (var item in array)
+                {
+                    stack.Push(item);
+                }
+
+                continue;
+            }
+
+            if (node is not PdfDictionary dict)
+            {
+                continue;
+            }
+
+            var resolved = TryResolvePageNumber(dict.GetAsDictionary(PdfName.Pg), pageObjNumToPageNumber);
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+
+            var nestedKids = dict.Get(PdfName.K);
+            if (nestedKids is not null && nestedKids is not PdfNull)
+            {
+                stack.Push(nestedKids);
+            }
+        }
+
+        return null;
+    }
+
+    private static int? TryResolvePageNumber(PdfDictionary? pageDict, Dictionary<int, int> pageObjNumToPageNumber)
+    {
+        if (pageDict is null)
+        {
+            return null;
+        }
+
+        var pageRef = pageDict.GetIndirectReference();
+        if (pageRef is null)
+        {
+            return null;
+        }
+
+        return pageObjNumToPageNumber.TryGetValue(pageRef.GetObjNumber(), out var pageNumber) ? pageNumber : null;
+    }
+
+    private static PdfObject Dereference(PdfObject obj, HashSet<(int objNum, int genNum)> visited)
+    {
+        if (obj is PdfIndirectReference reference)
+        {
+            var key = (reference.GetObjNumber(), reference.GetGenNumber());
+            if (!visited.Add(key))
+            {
+                return new PdfNull();
+            }
+
+            return reference.GetRefersTo(true) ?? new PdfNull();
+        }
+
+        return obj;
+    }
+
+    private static int CountImageXObjects(PdfDocument pdf)
+    {
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var count = 0;
+
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            var page = pdf.GetPage(pageNumber);
+            var resources = page.GetPdfObject().GetAsDictionary(PdfName.Resources);
+            count += CountImageXObjectsInResources(resources, visited);
+        }
+
+        return count;
+    }
+
+    private static int CountImageXObjectsInResources(PdfDictionary? resources, HashSet<(int objNum, int genNum)> visited)
+    {
+        if (resources is null)
+        {
+            return 0;
+        }
+
+        var xObjects = resources.GetAsDictionary(PdfName.XObject);
+        if (xObjects is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var key in xObjects.KeySet())
+        {
+            var xObject = xObjects.Get(key);
+            if (xObject is null || xObject is PdfNull)
+            {
+                continue;
+            }
+
+            var deref = Dereference(xObject, visited);
+            if (deref is not PdfStream stream)
+            {
+                continue;
+            }
+
+            var subtype = stream.GetAsName(PdfName.Subtype);
+            if (PdfName.Image.Equals(subtype))
+            {
+                count++;
+                continue;
+            }
+
+            if (PdfName.Form.Equals(subtype))
+            {
+                count += CountImageXObjectsInResources(stream.GetAsDictionary(PdfName.Resources), visited);
+            }
+        }
+
+        return count;
+    }
+
+    private static void ExtractImages(IReadOnlyList<ImageOccurrence> occurrences, string outputDir)
+    {
+        Directory.CreateDirectory(outputDir);
+
+        var seen = new HashSet<(int objNum, int genNum)>();
+        var inlineIndex = 0;
+        var extracted = 0;
+
+        foreach (var occ in occurrences)
+        {
+            var bytes = TryGetImageBytes(occ.Image);
+            if (bytes is null || bytes.Length == 0)
+            {
+                continue;
+            }
+
+            var ext = GuessImageExtension(bytes) ?? ".bin";
+
+            string fileName;
+            if (occ.ImageRef is not null)
+            {
+                var key = (objNum: occ.ImageRef.GetObjNumber(), genNum: occ.ImageRef.GetGenNumber());
+                if (!seen.Add(key))
+                {
+                    continue;
+                }
+
+                fileName = $"img-obj{key.objNum}-{key.genNum}{ext}";
+            }
+            else
+            {
+                fileName = $"img-inline-{inlineIndex++}{ext}";
+            }
+
+            var outPath = Path.Combine(outputDir, fileName);
+            File.WriteAllBytes(outPath, bytes);
+            extracted++;
+        }
+
+        Console.WriteLine($"Extracted {extracted} image file(s) to: {outputDir}");
+    }
+
+    private static byte[]? TryGetImageBytes(PdfImageXObject image)
+    {
+        try
+        {
+            return image.GetImageBytes(true);
+        }
+        catch
+        {
+            try
+            {
+                return image.GetImageBytes(false);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    private static string? GuessImageExtension(byte[] bytes)
+    {
+        if (LooksLikePng(bytes))
+        {
+            return ".png";
+        }
+
+        if (LooksLikeJpeg(bytes))
+        {
+            return ".jpg";
+        }
+
+        if (LooksLikeJpeg2000(bytes))
+        {
+            return ".jp2";
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikePng(byte[] bytes) =>
+        bytes.Length >= 8
+        && bytes[0] == 0x89
+        && bytes[1] == 0x50
+        && bytes[2] == 0x4E
+        && bytes[3] == 0x47
+        && bytes[4] == 0x0D
+        && bytes[5] == 0x0A
+        && bytes[6] == 0x1A
+        && bytes[7] == 0x0A;
+
+    private static bool LooksLikeJpeg(byte[] bytes) =>
+        bytes.Length >= 3
+        && bytes[0] == 0xFF
+        && bytes[1] == 0xD8
+        && bytes[2] == 0xFF;
+
+    private static bool LooksLikeJpeg2000(byte[] bytes) =>
+        bytes.Length >= 12
+        && bytes[0] == 0x00
+        && bytes[1] == 0x00
+        && bytes[2] == 0x00
+        && bytes[3] == 0x0C
+        && bytes[4] == 0x6A
+        && bytes[5] == 0x50
+        && bytes[6] == 0x20
+        && bytes[7] == 0x20
+        && bytes[8] == 0x0D
+        && bytes[9] == 0x0A
+        && bytes[10] == 0x87
+        && bytes[11] == 0x0A;
+}

--- a/tools/remediate.diagnostics.runner/README.md
+++ b/tools/remediate.diagnostics.runner/README.md
@@ -1,0 +1,21 @@
+# remediate.diagnostics.runner
+
+Small console runner for inspecting PDF remediation inputs (tag tree vs rendered images).
+
+It’s useful for understanding why a PDF ends up with the fallback alt text (e.g. `"alt text for image"`) on many
+`/Figure` elements.
+
+## Run
+
+From the repo root:
+
+```bash
+dotnet run --project tools/remediate.diagnostics.runner -- --input /path/to/file.pdf
+```
+
+Optionally extract unique raster images found during content-stream scanning:
+
+```bash
+dotnet run --project tools/remediate.diagnostics.runner -- --input /path/to/file.pdf --extract-images /tmp/extracted-images
+```
+

--- a/tools/remediate.diagnostics.runner/remediate.diagnostics.runner.csproj
+++ b/tools/remediate.diagnostics.runner/remediate.diagnostics.runner.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\server.core\server.core.csproj" />
+  </ItemGroup>
+
+</Project>
+


### PR DESCRIPTION
Adds support for generating alt text for vector figures in PDFs by rasterizing the figures and using an alt text service.

Significant changes:
- Introduces a rasterizer interface and a Docnet-based implementation.
- Implements logic to identify vector figures and crop/rasterize them.
- Utilizes the alt text service to generate descriptions from rasterized images.
