### PR TITLE
use primary lang for alt and title

### DIFF
--- a/server.core/Remediate/AltText/IAltTextService.cs
+++ b/server.core/Remediate/AltText/IAltTextService.cs
@@ -4,13 +4,15 @@ public sealed record ImageAltTextRequest(
     byte[] ImageBytes,
     string MimeType,
     string ContextBefore,
-    string ContextAfter);
+    string ContextAfter,
+    string? PrimaryLanguage = null);
 
 public sealed record LinkAltTextRequest(
     string? Target,
     string LinkText,
     string ContextBefore,
-    string ContextAfter);
+    string ContextAfter,
+    string? PrimaryLanguage = null);
 
 public interface IAltTextService
 {
@@ -20,4 +22,3 @@ public interface IAltTextService
     string GetFallbackAltTextForImage();
     string GetFallbackAltTextForLink();
 }
-

--- a/server.core/Remediate/AltText/OpenAIAltTextService.cs
+++ b/server.core/Remediate/AltText/OpenAIAltTextService.cs
@@ -39,7 +39,7 @@ public sealed class OpenAIAltTextService : IAltTextService
 
         List<ChatMessage> messages =
         [
-            new SystemChatMessage(BuildSystemInstructions()),
+            new SystemChatMessage(BuildSystemInstructions(request.PrimaryLanguage)),
             new UserChatMessage(
                 ChatMessageContentPart.CreateTextPart(prompt),
                 ChatMessageContentPart.CreateImagePart(imageData, request.MimeType)),
@@ -59,7 +59,7 @@ public sealed class OpenAIAltTextService : IAltTextService
 
         List<ChatMessage> messages =
         [
-            new SystemChatMessage(BuildSystemInstructions()),
+            new SystemChatMessage(BuildSystemInstructions(request.PrimaryLanguage)),
             new UserChatMessage(BuildLinkPrompt(request.Target, request.LinkText, request.ContextBefore, request.ContextAfter)),
         ];
 
@@ -75,12 +75,23 @@ public sealed class OpenAIAltTextService : IAltTextService
     /// <summary>
     /// Returns the system instructions used to constrain response formatting.
     /// </summary>
-    private static string BuildSystemInstructions() =>
-        """
-        You write WCAG 2.1-compliant PDF alt text.
-        Return ONLY the alt text (no quotes, no markdown, and no extra commentary).
-        Keep it concise (short phrase or one sentence) and do not start with "Image of".
-        """;
+    private static string BuildSystemInstructions(string? primaryLanguage)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("You write WCAG 2.1-compliant PDF alt text.");
+        sb.AppendLine("Return ONLY the alt text (no quotes, no markdown, and no extra commentary).");
+        sb.AppendLine("Keep it concise (short phrase or one sentence) and do not start with \"Image of\".");
+
+        var normalizedLanguage = RemediationHelpers.NormalizeWhitespace(primaryLanguage ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(normalizedLanguage))
+        {
+            sb.Append("Write the alt text in the document's primary language (");
+            sb.Append(normalizedLanguage);
+            sb.AppendLine(").");
+        }
+
+        return sb.ToString().Trim();
+    }
 
     private static string BuildImagePrompt(string contextBefore, string contextAfter)
     {

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -147,14 +147,15 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
             using var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath));
 
-            using (LogStage.Begin(_logger, fileId, "ensure_title", null, kind: "Remediation stage"))
-            {
-                await EnsurePdfHasTitleAsync(pdf, cancellationToken);
-            }
-
             using (LogStage.Begin(_logger, fileId, "ensure_primary_language", null, kind: "Remediation stage"))
             {
                 EnsurePdfHasPrimaryLanguage(pdf, cancellationToken);
+            }
+            var primaryLanguage = GetPrimaryLanguage(pdf);
+
+            using (LogStage.Begin(_logger, fileId, "ensure_title", null, kind: "Remediation stage"))
+            {
+                await EnsurePdfHasTitleAsync(pdf, primaryLanguage, cancellationToken);
             }
 
             var isTagged = pdf.IsTagged();
@@ -268,7 +269,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                         var (bytes, mimeType) = ExtractImageBytes(occ.Image);
                         var altText = await _altTextService.GetAltTextForImageAsync(
-                            new ImageAltTextRequest(bytes, mimeType, occ.ContextBefore, occ.ContextAfter),
+                            new ImageAltTextRequest(bytes, mimeType, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
                             cancellationToken);
                         SetAlt(figure, altText);
                         if (!string.IsNullOrWhiteSpace(altText))
@@ -300,7 +301,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                         var target = TryGetLinkTarget(occ.LinkAnnotation);
                         var altText = await _altTextService.GetAltTextForLinkAsync(
-                            new LinkAltTextRequest(target, occ.LinkText, occ.ContextBefore, occ.ContextAfter),
+                            new LinkAltTextRequest(target, occ.LinkText, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
                             cancellationToken);
                         SetAlt(link, altText);
                         if (!string.IsNullOrWhiteSpace(altText))
@@ -533,7 +534,12 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                                         try
                                         {
                                             altText = await _altTextService.GetAltTextForImageAsync(
-                                                new ImageAltTextRequest(pngBytes, "image/png", candidate.ContextBefore, candidate.ContextAfter),
+                                                new ImageAltTextRequest(
+                                                    pngBytes,
+                                                    "image/png",
+                                                    candidate.ContextBefore,
+                                                    candidate.ContextAfter,
+                                                    primaryLanguage),
                                                 cancellationToken);
                                         }
                                         catch (OperationCanceledException)
@@ -677,7 +683,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
     /// <summary>
     /// Ensures the PDF metadata has a reasonable title, generating one from early-page text when possible.
     /// </summary>
-    private async Task EnsurePdfHasTitleAsync(PdfDocument pdf, CancellationToken cancellationToken)
+    private async Task EnsurePdfHasTitleAsync(
+        PdfDocument pdf,
+        string? primaryLanguage,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -701,7 +710,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
         }
 
         var suggestedTitle = await _pdfTitleService.GenerateTitleAsync(
-            new PdfTitleRequest(currentTitle, extractedText),
+            new PdfTitleRequest(currentTitle, extractedText, primaryLanguage),
             cancellationToken);
 
         suggestedTitle = NormalizeTitle(suggestedTitle, fallback: currentTitle);
@@ -750,6 +759,14 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
             maxPagesToScan: TitleContextMaxPages,
             minWords: LangContextMinWords,
             cancellationToken: cancellationToken);
+    }
+
+    private static string? GetPrimaryLanguage(PdfDocument pdf)
+    {
+        var language = RemediationHelpers.NormalizeWhitespace(
+            pdf.GetCatalog().GetPdfObject().GetAsString(PdfName.Lang)?.ToUnicodeString() ?? string.Empty);
+
+        return string.IsNullOrWhiteSpace(language) ? null : language;
     }
 
     /// <summary>

--- a/server.core/Remediate/Title/IPdfTitleService.cs
+++ b/server.core/Remediate/Title/IPdfTitleService.cs
@@ -1,9 +1,8 @@
 namespace server.core.Remediate.Title;
 
-public sealed record PdfTitleRequest(string CurrentTitle, string ExtractedText);
+public sealed record PdfTitleRequest(string CurrentTitle, string ExtractedText, string? PrimaryLanguage = null);
 
 public interface IPdfTitleService
 {
     Task<string> GenerateTitleAsync(PdfTitleRequest request, CancellationToken cancellationToken);
 }
-

--- a/server.core/Remediate/Title/OpenAIPdfTitleService.cs
+++ b/server.core/Remediate/Title/OpenAIPdfTitleService.cs
@@ -34,7 +34,7 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var prompt = BuildPrompt(request.CurrentTitle, request.ExtractedText);
+        var prompt = BuildPrompt(request.CurrentTitle, request.ExtractedText, request.PrimaryLanguage);
 
         List<ChatMessage> messages =
         [
@@ -50,10 +50,11 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
     /// <summary>
     /// Builds a prompt that asks for a single plain-text title and includes current title and extracted context.
     /// </summary>
-    private static string BuildPrompt(string currentTitle, string extractedText)
+    private static string BuildPrompt(string currentTitle, string extractedText, string? primaryLanguage)
     {
         currentTitle = RemediationHelpers.NormalizeWhitespace(currentTitle);
         extractedText = RemediationHelpers.NormalizeWhitespace(extractedText);
+        primaryLanguage = RemediationHelpers.NormalizeWhitespace(primaryLanguage ?? string.Empty);
 
         var sb = new StringBuilder();
         sb.AppendLine(
@@ -68,6 +69,14 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
             + "If you think the current title is good enough based on the context, reply with the current title and nothing else. "
             + "Otherwise, generate a new title based on the provided context.");
         sb.AppendLine();
+        if (!string.IsNullOrWhiteSpace(primaryLanguage))
+        {
+            sb.Append("Primary Document Language: ");
+            sb.AppendLine(primaryLanguage);
+            sb.AppendLine("Write the title in this language.");
+            sb.AppendLine();
+        }
+
         sb.Append("Current File Title: ");
         sb.AppendLine(string.IsNullOrWhiteSpace(currentTitle) ? "(none)" : currentTitle);
         sb.AppendLine("Context for title generation:");

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorImageExtractionTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorImageExtractionTests.cs
@@ -58,6 +58,50 @@ public sealed class PdfRemediationProcessorImageExtractionTests
         }
     }
 
+    [Fact]
+    public async Task ProcessAsync_TaggedMissingAlt_PassesPrimaryLanguageToAltTextService()
+    {
+        var repoRoot = FindRepoRoot();
+        var fixturePath = Path.Combine(repoRoot, "tests", "server.tests", "Fixtures", "pdfs", "tagged-missing-alt.pdf");
+        File.Exists(fixturePath).Should().BeTrue($"fixture should exist at {fixturePath}");
+
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-img-lang-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input-with-lang.pdf");
+            using (var pdf = new PdfDocument(new PdfReader(fixturePath), new PdfWriter(inputPdfPath)))
+            {
+                pdf.GetCatalog().GetPdfObject().Put(PdfName.Lang, new PdfString("fr-CA"));
+            }
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var altText = new CapturingAltTextService();
+            var sut = new PdfRemediationProcessor(
+                altText,
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            altText.ImageRequests.Should().NotBeEmpty();
+            altText.ImageRequests.Should().OnlyContain(r => r.PrimaryLanguage == "fr-CA");
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
     private sealed class CapturingAltTextService : IAltTextService
     {
         public List<ImageAltTextRequest> ImageRequests { get; } = new();

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTitleTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTitleTests.cs
@@ -69,6 +69,51 @@ public sealed class PdfRemediationProcessorTitleTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WhenLangSet_PassesLangToTitleService()
+    {
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-title-lang-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreatePdf(
+                inputPdfPath,
+                title: null,
+                pages:
+                [
+                    MakePageText("Documento", wordCount: 120),
+                ],
+                existingLang: "es-MX");
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+
+            var titleService = new CapturingPdfTitleService { TitleToReturn = "Nuevo titulo" };
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                titleService,
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            titleService.Requests.Should().ContainSingle();
+            titleService.Requests[0].PrimaryLanguage.Should().Be("es-MX");
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ProcessAsync_WhenEnoughTextAndHasTitle_KeepsExistingTitleWithoutCallingAi()
     {
         var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-title-keep-enough-text-{Guid.NewGuid():N}");
@@ -221,13 +266,18 @@ public sealed class PdfRemediationProcessorTitleTests
         return string.Join(' ', new[] { token }.Concat(Enumerable.Repeat("word", wordCount - 1)));
     }
 
-    private static void CreatePdf(string path, string? title, IReadOnlyList<string> pages)
+    private static void CreatePdf(string path, string? title, IReadOnlyList<string> pages, string? existingLang = null)
     {
         using var writer = new PdfWriter(path);
         using var pdf = new PdfDocument(writer);
         if (!string.IsNullOrWhiteSpace(title))
         {
             pdf.GetDocumentInfo().SetTitle(title);
+        }
+
+        if (!string.IsNullOrWhiteSpace(existingLang))
+        {
+            pdf.GetCatalog().GetPdfObject().Put(PdfName.Lang, new PdfString(existingLang));
         }
 
         using var doc = new Document(pdf);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF documents now automatically detect and utilize their primary language metadata during alt text and title generation, ensuring generated content matches the document's language.

* **Tests**
  * Added integration tests verifying language metadata is properly propagated throughout the remediation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->