### PR TITLE
Requires authentication for status banner

### DIFF
--- a/server/Controllers/StatusController.cs
+++ b/server/Controllers/StatusController.cs
@@ -12,7 +12,6 @@ public class StatusController : ApiControllerBase
         _configuration = configuration;
     }
 
-    [AllowAnonymous]
     [HttpGet("banner")]
     [ResponseCache(Duration = 60)]
     public async Task<IActionResult> GetBanner()


### PR DESCRIPTION
Removes the AllowAnonymous attribute from the banner endpoint to ensure it is only accessible to authenticated users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The banner endpoint now requires proper authentication and authorization based on configured access policies, enhancing application security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->