### PR TITLE
Adds PDF page limit notification

### DIFF
--- a/client/src/components/pdf/PdfUploadDropzone.tsx
+++ b/client/src/components/pdf/PdfUploadDropzone.tsx
@@ -81,6 +81,9 @@ export function PdfUploadDropzone({
       <div className="mt-3 text-xs text-base-content/70">
         PDF only · Multiple files supported
       </div>
+      <div className="alert alert-primary mt-4 max-w-md text-left text-sm">
+        <span>Temporary upload limit: PDFs must be 25 pages or fewer.</span>
+      </div>
       <p className="mt-2 max-w-sm text-xs text-base-content/60">
         Best results come from text-based PDFs. Scanned, handwritten, or
         image-only content may need manual transcription first.{' '}

--- a/server.core/Ingest/FileIngestOptions.cs
+++ b/server.core/Ingest/FileIngestOptions.cs
@@ -8,6 +8,7 @@ public sealed class FileIngestOptions
     public bool AutotagTaggedPdfs { get; set; }
 
     public int PdfMaxPagesPerChunk { get; set; } = 200;
+    public int MaxUploadPages { get; set; }
     public string? PdfWorkDirRoot { get; set; }
 
     public void UseNoops()
@@ -16,5 +17,6 @@ public sealed class FileIngestOptions
         UsePdfRemediationProcessor = false;
         UsePdfBookmarks = false;
         AutotagTaggedPdfs = false;
+        MaxUploadPages = 0;
     }
 }

--- a/server.core/Ingest/FileIngestProcessor.cs
+++ b/server.core/Ingest/FileIngestProcessor.cs
@@ -187,6 +187,11 @@ public sealed class FileIngestProcessor : IFileIngestProcessor
         }
         catch (Exception ex)
         {
+            if (ex is PdfPageLimitExceededException pageLimitExceededException)
+            {
+                pageCount = pageLimitExceededException.ActualPageCount;
+            }
+
             _logger.LogError(
                 ex,
                 "Ingest failed for {fileId} elapsedMs={elapsedMs}",

--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class IngestServiceCollectionExtensions
             o.UsePdfBookmarks = options.UsePdfBookmarks;
             o.AutotagTaggedPdfs = options.AutotagTaggedPdfs;
             o.MaxPagesPerChunk = options.PdfMaxPagesPerChunk;
+            o.MaxUploadPages = options.MaxUploadPages;
             o.WorkDirRoot = options.PdfWorkDirRoot;
         });
         services.AddSingleton<IBlobStreamOpener, AzureBlobStreamOpener>();

--- a/server.core/Ingest/PdfPageLimitExceededException.cs
+++ b/server.core/Ingest/PdfPageLimitExceededException.cs
@@ -1,0 +1,15 @@
+namespace server.core.Ingest;
+
+public sealed class PdfPageLimitExceededException : Exception
+{
+    public PdfPageLimitExceededException(int actualPageCount, int maxAllowedPages)
+        : base($"PDF has {actualPageCount} pages; maximum allowed is {maxAllowedPages}.")
+    {
+        ActualPageCount = actualPageCount;
+        MaxAllowedPages = maxAllowedPages;
+    }
+
+    public int ActualPageCount { get; }
+
+    public int MaxAllowedPages { get; }
+}

--- a/server.core/Ingest/PdfProcessor.cs
+++ b/server.core/Ingest/PdfProcessor.cs
@@ -52,6 +52,14 @@ public sealed class PdfProcessor : IPdfProcessor
                 _options.MaxPagesPerChunk,
                 "MaxPagesPerChunk must be > 0.");
         }
+
+        if (_options.MaxUploadPages < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(_options.MaxUploadPages),
+                _options.MaxUploadPages,
+                "MaxUploadPages must be >= 0.");
+        }
     }
 
     /// <summary>
@@ -85,6 +93,9 @@ public sealed class PdfProcessor : IPdfProcessor
         {
             // ignore
         }
+
+        var sourcePageCount = TryReadPageCount(sourcePath);
+        EnforceMaxUploadPages(sourcePageCount);
 
         // Best-effort: generate a "before" accessibility report on the original uploaded PDF.
         AdobeAccessibilityCheckOutput? beforeAccessibilityReport = null;
@@ -342,6 +353,21 @@ public sealed class PdfProcessor : IPdfProcessor
     }
 
     private sealed record SourcePdfInfo(int PageCount, PdfTaggingState TaggingState);
+
+    private void EnforceMaxUploadPages(int pageCount)
+    {
+        if (_options.MaxUploadPages <= 0 || pageCount <= 0 || pageCount <= _options.MaxUploadPages)
+        {
+            return;
+        }
+
+        _logger.LogWarning(
+            "Rejecting PDF because it exceeds the configured page limit: actualPages={actualPages} maxAllowedPages={maxAllowedPages}",
+            pageCount,
+            _options.MaxUploadPages);
+
+        throw new PdfPageLimitExceededException(pageCount, _options.MaxUploadPages);
+    }
 
     private static int TryReadPageCount(string pdfPath)
     {

--- a/server.core/Ingest/PdfProcessorOptions.cs
+++ b/server.core/Ingest/PdfProcessorOptions.cs
@@ -28,6 +28,12 @@ public sealed class PdfProcessorOptions
     public int MaxPagesPerChunk { get; set; } = 200;
 
     /// <summary>
+    /// Maximum allowed page count for uploaded PDFs.
+    /// Set to 0 or less to disable the limit.
+    /// </summary>
+    public int MaxUploadPages { get; set; }
+
+    /// <summary>
     /// Root directory for PDF ingest work. If null/empty, defaults to /tmp (when available) or <see cref="Path.GetTempPath"/>.
     /// </summary>
     public string? WorkDirRoot { get; set; }

--- a/tests/server.tests/Ingest/FileIngestProcessorTests.cs
+++ b/tests/server.tests/Ingest/FileIngestProcessorTests.cs
@@ -231,6 +231,81 @@ public class FileIngestProcessorTests
         opener.Seen.Should().BeNull();
     }
 
+    [Fact]
+    public async Task ProcessAsync_WhenPdfExceedsPageLimit_MarksAttemptFailedAndPersistsPageCount()
+    {
+        var fileId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"ingest_{Guid.NewGuid():N}")
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        await using (var seed = new AppDbContext(options))
+        {
+            seed.Database.EnsureCreated();
+
+            var user = new User
+            {
+                UserId = 1,
+                EntraObjectId = Guid.NewGuid(),
+                Email = "test@example.com",
+                DisplayName = "Test User",
+            };
+
+            seed.Users.Add(user);
+            seed.Files.Add(new FileRecord
+            {
+                FileId = fileId,
+                OwnerUserId = user.UserId,
+                OwnerUser = user,
+                OriginalFileName = "too-many-pages.pdf",
+                ContentType = "application/pdf",
+                SizeBytes = 123,
+                Status = FileRecord.Statuses.Queued,
+                CreatedAt = DateTimeOffset.UtcNow,
+                StatusUpdatedAt = DateTimeOffset.UtcNow,
+            });
+
+            await seed.SaveChangesAsync();
+        }
+
+        var dbContextFactory = new InMemoryDbContextFactory(options);
+        var opener = new FakeBlobStreamOpener();
+        var pdf = new PageLimitThrowingPdfProcessor();
+        var blobStorage = new FakeBlobStorage();
+        var configuration = new ConfigurationBuilder().Build();
+        using var loggerFactory = LoggerFactory.Create(_ => { });
+
+        var sut = new FileIngestProcessor(
+            dbContextFactory,
+            opener,
+            pdf,
+            blobStorage,
+            configuration,
+            loggerFactory.CreateLogger<FileIngestProcessor>());
+
+        var request = new BlobIngestRequest(
+            new Uri("https://example.blob.core.windows.net/incoming/abc123.pdf"),
+            "incoming",
+            "abc123.pdf",
+            fileId.ToString());
+
+        Func<Task> act = () => sut.ProcessAsync(request, CancellationToken.None);
+        var ex = await act.Should().ThrowAsync<PdfPageLimitExceededException>();
+        ex.Which.ActualPageCount.Should().Be(pdf.ActualPageCount);
+        ex.Which.MaxAllowedPages.Should().Be(pdf.MaxAllowedPages);
+
+        await using var verify = new AppDbContext(options);
+        var file = await verify.Files.SingleAsync(x => x.FileId == fileId);
+        file.Status.Should().Be(FileRecord.Statuses.Failed);
+        file.PageCount.Should().Be(pdf.ActualPageCount);
+
+        var attempt = await verify.FileProcessingAttempts.SingleAsync(x => x.FileId == fileId);
+        attempt.Outcome.Should().Be(FileProcessingAttempt.Outcomes.Failed);
+        attempt.ErrorCode.Should().Be(nameof(PdfPageLimitExceededException));
+        attempt.ErrorMessage.Should().Be($"PDF has {pdf.ActualPageCount} pages; maximum allowed is {pdf.MaxAllowedPages}.");
+    }
+
     private sealed class InMemoryDbContextFactory : IDbContextFactory<AppDbContext>
     {
         private readonly DbContextOptions<AppDbContext> _options;
@@ -327,6 +402,17 @@ public class FileIngestProcessorTests
         public Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
         {
             throw new InvalidOperationException("boom");
+        }
+    }
+
+    private sealed class PageLimitThrowingPdfProcessor : IPdfProcessor
+    {
+        public int ActualPageCount { get; } = 31;
+        public int MaxAllowedPages { get; } = 25;
+
+        public Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
+        {
+            throw new PdfPageLimitExceededException(ActualPageCount, MaxAllowedPages);
         }
     }
 

--- a/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
+++ b/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
@@ -253,11 +253,101 @@ public sealed class PdfProcessorIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task ProcessAsync_WhenMaxUploadPagesExceeded_ThrowsBeforeAdobeOrRemediation()
+    {
+        var fileId = $"pdf-page-limit-test-{Guid.NewGuid():N}";
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", fileId);
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTestPdf(inputPdfPath, pageCount: 26);
+
+            await using var inputStream = File.OpenRead(inputPdfPath);
+
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+            var adobe = new CapturingAdobePdfServices();
+            var remediation = new CapturingRemediationProcessor();
+            var options = Options.Create(new PdfProcessorOptions
+            {
+                UseAdobePdfServices = true,
+                UsePdfRemediationProcessor = true,
+                MaxPagesPerChunk = 200,
+                MaxUploadPages = 25,
+                WorkDirRoot = runRoot
+            });
+
+            var sut = new PdfProcessor(adobe, remediation, options, loggerFactory.CreateLogger<PdfProcessor>());
+
+            var act = () => sut.ProcessAsync(fileId, inputStream, CancellationToken.None);
+
+            var ex = await act.Should().ThrowAsync<PdfPageLimitExceededException>();
+            ex.Which.ActualPageCount.Should().Be(26);
+            ex.Which.MaxAllowedPages.Should().Be(25);
+            adobe.AutotagCalls.Should().Be(0);
+            adobe.AccessibilityCheckCalls.Should().Be(0);
+            remediation.Calls.Should().Be(0);
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenMaxUploadPagesDisabled_DoesNotRejectLargePdf()
+    {
+        var fileId = $"pdf-page-limit-disabled-test-{Guid.NewGuid():N}";
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", fileId);
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTestPdf(inputPdfPath, pageCount: 26);
+
+            await using var inputStream = File.OpenRead(inputPdfPath);
+
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+            var adobe = new NoopAdobePdfServices(loggerFactory.CreateLogger<NoopAdobePdfServices>());
+            var remediation = new NoopPdfRemediationProcessor();
+            var options = Options.Create(new PdfProcessorOptions
+            {
+                UseAdobePdfServices = false,
+                UsePdfRemediationProcessor = false,
+                MaxPagesPerChunk = 200,
+                MaxUploadPages = 0,
+                WorkDirRoot = runRoot
+            });
+
+            var sut = new PdfProcessor(adobe, remediation, options, loggerFactory.CreateLogger<PdfProcessor>());
+
+            var result = await sut.ProcessAsync(fileId, inputStream, CancellationToken.None);
+
+            result.PageCount.Should().Be(26);
+            result.OutputPdfPath.Should().EndWith(".source.pdf");
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
     private sealed record AdobeCall(string InputPdfPath, string OutputTaggedPdfPath, string OutputTaggingReportPath);
 
     private sealed class CapturingAdobePdfServices : IAdobePdfServices
     {
         public List<AdobeCall> Calls { get; } = [];
+        public int AccessibilityCheckCalls { get; private set; }
+        public int AutotagCalls => Calls.Count;
 
         public async Task<AdobeAutotagOutput> AutotagPdfAsync(
             string inputPdfPath,
@@ -288,13 +378,34 @@ public sealed class PdfProcessorIntegrationTests
             int? pageEnd,
             CancellationToken cancellationToken)
         {
-            _ = inputPdfPath;
-            _ = outputPdfPath;
-            _ = outputReportPath;
-            _ = pageStart;
-            _ = pageEnd;
             cancellationToken.ThrowIfCancellationRequested();
-            throw new NotSupportedException("Not needed for this test.");
+            AccessibilityCheckCalls++;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPdfPath)!);
+            File.Copy(inputPdfPath, outputPdfPath, overwrite: true);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputReportPath)!);
+            File.WriteAllText(outputReportPath, "{\"Summary\":{\"Failed\":0}}");
+
+            return Task.FromResult(new AdobeAccessibilityCheckOutput(
+                outputPdfPath,
+                outputReportPath,
+                "{\"Summary\":{\"Failed\":0}}"));
+        }
+    }
+
+    private sealed class CapturingRemediationProcessor : IPdfRemediationProcessor
+    {
+        public int Calls { get; private set; }
+
+        public Task<PdfRemediationResult> ProcessAsync(
+            string fileId,
+            string inputPdfPath,
+            string outputPdfPath,
+            CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(new PdfRemediationResult(outputPdfPath));
         }
     }
 

--- a/workers/function.ingest/Program.cs
+++ b/workers/function.ingest/Program.cs
@@ -51,6 +51,10 @@ builder.Services.AddFileIngest(o =>
         builder.Configuration.GetValue<bool?>("Ingest:UsePdfBookmarks")
         ?? builder.Configuration.GetValue<bool?>("INGEST_USE_PDF_BOOKMARKS")
         ?? true;
+    o.MaxUploadPages =
+        builder.Configuration.GetValue<int?>("Ingest:MaxUploadPages")
+        ?? builder.Configuration.GetValue<int?>("INGEST_MAX_UPLOAD_PAGES")
+        ?? 25;
 });
 
 builder.Services.AddApplicationInsightsTelemetryWorkerService();


### PR DESCRIPTION
Displays a temporary user-facing message within the PDF upload dropzone. This informs users about an active upload limit, specifying that PDFs must be 25 pages or fewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a temporary upload limit for PDF files, capped at 25 pages maximum.
  * Added a notification on the upload interface informing users of the page limit.
  * Uploads exceeding the limit are rejected with a clear error message indicating the maximum allowed pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->