### PR TITLE
Adds a maximum page count limit for PDF uploads and ingest

### DIFF
--- a/client/src/components/pdf/PdfActivityCard.tsx
+++ b/client/src/components/pdf/PdfActivityCard.tsx
@@ -398,6 +398,8 @@ export function PdfActivityCard({
                     typeof afterIssues === 'number'
                       ? beforeIssues - afterIssues
                       : null;
+                  const failedReason =
+                    file.status === 'Failed' ? file.processingErrorMessage : null;
 
                   return (
                     <tr className="group" key={file.fileId}>
@@ -435,6 +437,12 @@ export function PdfActivityCard({
                             </span>
                           ) : null}
 
+                          {failedReason ? (
+                            <p className="max-w-xs text-sm text-error">
+                              {failedReason}
+                            </p>
+                          ) : null}
+
                           {upload ? (
                             <progress className="progress progress-primary w-full" />
                           ) : null}
@@ -453,7 +461,9 @@ export function PdfActivityCard({
 
                       {/* Report */}
                       <td className="text-base">
-                        {file.status !== 'Completed' ? (
+                        {file.status === 'Failed' && failedReason ? (
+                          <span className="text-error">Processing failed</span>
+                        ) : file.status !== 'Completed' ? (
                           <span className="text-base-content/70">—</span>
                         ) : !afterReport ? (
                           <span className="text-base-content/70">
@@ -581,3 +591,6 @@ export function PdfActivityCard({
     </div>
   );
 }
+
+
+

--- a/client/src/components/pdf/PdfActivityCard.tsx
+++ b/client/src/components/pdf/PdfActivityCard.tsx
@@ -222,7 +222,7 @@ export function PdfActivityCard({
             className="input input-bordered w-full max-w-xs placeholder:text-base-content/80"
             id="pdf-file-filter"
             onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter by filename…"
+            placeholder="Filter by filenameâ€¦"
             type="search"
             value={filter}
           />
@@ -245,7 +245,7 @@ export function PdfActivityCard({
               >
                 <ArrowDownTrayIcon className="h-4 w-4" />
                 {zipMutation.isPending
-                  ? 'Preparing zip…'
+                  ? 'Preparing zipâ€¦'
                   : completedSelectedCount > MAX_BATCH_SIZE
                     ? `Max ${MAX_BATCH_SIZE} files per ZIP`
                     : `Download ${completedSelectedCount} as ZIP`}
@@ -268,7 +268,7 @@ export function PdfActivityCard({
               >
                 <TrashIcon className="h-4 w-4" />
                 {archiveMutation.isPending
-                  ? 'Deleting…'
+                  ? 'Deletingâ€¦'
                   : selectedCount > MAX_BATCH_SIZE
                     ? `Max ${MAX_BATCH_SIZE} files per delete`
                     : `Delete ${selectedCount} file${selectedCount === 1 ? '' : 's'}`}
@@ -284,7 +284,7 @@ export function PdfActivityCard({
               >
                 <ArrowUturnLeftIcon className="h-4 w-4" />
                 {undeleteMutation.isPending
-                  ? 'Restoring…'
+                  ? 'Restoringâ€¦'
                   : `Undo delete (${recentlyDeletedIds.length} file${
                       recentlyDeletedIds.length === 1 ? '' : 's'
                     })`}
@@ -371,7 +371,7 @@ export function PdfActivityCard({
                   <td className="text-base-content/70" colSpan={5}>
                     <div className="flex items-center gap-3">
                       <span className="loading loading-spinner loading-sm" />
-                      <span>Loading…</span>
+                      <span>Loadingâ€¦</span>
                     </div>
                   </td>
                 </tr>
@@ -426,7 +426,15 @@ export function PdfActivityCard({
                       <td>
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
-                            <span className="badge badge-primary badge-soft">
+                            <span
+                              aria-label={
+                                failedReason
+                                  ? `Failure reason: ${failedReason}`
+                                  : undefined
+                              }
+                              className="badge badge-primary badge-soft"
+                              title={failedReason ?? undefined}
+                            >
                               {file.status}
                             </span>
                           </div>
@@ -437,11 +445,6 @@ export function PdfActivityCard({
                             </span>
                           ) : null}
 
-                          {failedReason ? (
-                            <p className="max-w-xs text-sm text-error">
-                              {failedReason}
-                            </p>
-                          ) : null}
 
                           {upload ? (
                             <progress className="progress progress-primary w-full" />
@@ -454,7 +457,7 @@ export function PdfActivityCard({
                         {file.originalFileName}
                         <br />
                         <span className="text-sm text-base-content/70">
-                          {formatBytes(file.sizeBytes)} •{' '}
+                          {formatBytes(file.sizeBytes)} â€¢{' '}
                           {formatDateTime(file.createdAt)}
                         </span>
                       </td>
@@ -464,14 +467,14 @@ export function PdfActivityCard({
                         {file.status === 'Failed' && failedReason ? (
                           <span className="text-error">Processing failed</span>
                         ) : file.status !== 'Completed' ? (
-                          <span className="text-base-content/70">—</span>
+                          <span className="text-base-content/70">â€”</span>
                         ) : !afterReport ? (
                           <span className="text-base-content/70">
                             No report yet
                           </span>
                         ) : afterIssues === null ? (
                           <div className="">
-                            Report ready • After:{' '}
+                            Report ready â€¢ After:{' '}
                             {formatDateTime(afterReport.generatedAt)}
                           </div>
                         ) : (
@@ -496,12 +499,12 @@ export function PdfActivityCard({
                             <div>
                               {typeof beforeIssues === 'number' ? (
                                 <>
-                                  Issues: {beforeIssues} → {afterIssues}
+                                  Issues: {beforeIssues} â†’ {afterIssues}
                                 </>
                               ) : (
                                 <>Issues remaining: {afterIssues}</>
                               )}{' '}
-                              • After: {formatDateTime(afterReport.generatedAt)}
+                              â€¢ After: {formatDateTime(afterReport.generatedAt)}
                             </div>
                           </div>
                         )}
@@ -591,6 +594,8 @@ export function PdfActivityCard({
     </div>
   );
 }
+
+
 
 
 

--- a/client/src/queries/files.ts
+++ b/client/src/queries/files.ts
@@ -30,6 +30,7 @@ export type UserFile = {
   createdAt: string;
   fileId: string;
   originalFileName: string;
+  processingErrorMessage?: string | null;
   sizeBytes: number;
   status: string;
   statusUpdatedAt: string;
@@ -145,3 +146,5 @@ export function useDownloadFilesAsZipMutation() {
     mutationFn: (fileIds: string[]) => downloadFilesAsZip(fileIds),
   });
 }
+
+

--- a/client/src/test/routes/(authenticated)/index.test.tsx
+++ b/client/src/test/routes/(authenticated)/index.test.tsx
@@ -36,11 +36,15 @@ describe('authenticated index route', () => {
     const { cleanup } = renderRoute({ initialPath: '/' });
 
     try {
-      expect(
-        await screen.findByText(
-          'PDFs are temporarily limited to 25 pages. This file has 26 pages.'
-        )
-      ).toBeInTheDocument();
+      const failedBadge = await screen.findByText('Failed');
+      expect(failedBadge).toHaveAttribute(
+        'title',
+        'PDFs are temporarily limited to 25 pages. This file has 26 pages.'
+      );
+      expect(failedBadge).toHaveAttribute(
+        'aria-label',
+        'Failure reason: PDFs are temporarily limited to 25 pages. This file has 26 pages.'
+      );
       expect(await screen.findByText('Processing failed')).toBeInTheDocument();
     } finally {
       cleanup();
@@ -92,4 +96,6 @@ describe('authenticated index route', () => {
     }
   });
 });
+
+
 

--- a/client/src/test/routes/(authenticated)/index.test.tsx
+++ b/client/src/test/routes/(authenticated)/index.test.tsx
@@ -5,6 +5,47 @@ import { server } from '@/test/mswUtils.ts';
 import { renderRoute } from '@/test/routerUtils.tsx';
 
 describe('authenticated index route', () => {
+  it('renders the latest processing failure reason for failed files', async () => {
+    server.use(
+      http.get('/api/user/me', () => {
+        return HttpResponse.json({
+          email: 'user@example.com',
+          id: 'user-1',
+          name: 'Test User',
+          roles: [],
+        });
+      }),
+      http.get('/api/file', () => {
+        return HttpResponse.json([
+          {
+            accessibilityReports: [],
+            contentType: 'application/pdf',
+            createdAt: '2026-03-11T00:00:00Z',
+            fileId: 'file-1',
+            originalFileName: 'too-many-pages.pdf',
+            processingErrorMessage:
+              'PDFs are temporarily limited to 25 pages. This file has 26 pages.',
+            sizeBytes: 1024,
+            status: 'Failed',
+            statusUpdatedAt: '2026-03-11T00:01:00Z',
+          },
+        ]);
+      })
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/' });
+
+    try {
+      expect(
+        await screen.findByText(
+          'PDFs are temporarily limited to 25 pages. This file has 26 pages.'
+        )
+      ).toBeInTheDocument();
+      expect(await screen.findByText('Processing failed')).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
   it('renders the PDF upload experience', async () => {
     // arrange
     let filesRequestCount = 0;
@@ -51,3 +92,4 @@ describe('authenticated index route', () => {
     }
   });
 });
+

--- a/server.core/Ingest/FileIngestOptions.cs
+++ b/server.core/Ingest/FileIngestOptions.cs
@@ -7,6 +7,7 @@ public sealed class FileIngestOptions
     public bool UsePdfBookmarks { get; set; }
     public bool AutotagTaggedPdfs { get; set; }
 
+    public int PdfMaxPageCount { get; set; } = 25;
     public int PdfMaxPagesPerChunk { get; set; } = 200;
     public string? PdfWorkDirRoot { get; set; }
 
@@ -18,3 +19,4 @@ public sealed class FileIngestOptions
         AutotagTaggedPdfs = false;
     }
 }
+

--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class IngestServiceCollectionExtensions
             o.UsePdfRemediationProcessor = options.UsePdfRemediationProcessor;
             o.UsePdfBookmarks = options.UsePdfBookmarks;
             o.AutotagTaggedPdfs = options.AutotagTaggedPdfs;
+            o.MaxPageCount = options.PdfMaxPageCount;
             o.MaxPagesPerChunk = options.PdfMaxPagesPerChunk;
             o.WorkDirRoot = options.PdfWorkDirRoot;
         });
@@ -150,3 +151,4 @@ public static class IngestServiceCollectionExtensions
 
     private sealed record OpenAiRemediationConfig(string ApiKey, string AltTextModel, string PdfTitleModel);
 }
+

--- a/server.core/Ingest/PdfPageCounter.cs
+++ b/server.core/Ingest/PdfPageCounter.cs
@@ -1,0 +1,18 @@
+using iText.Kernel.Pdf;
+
+namespace server.core.Ingest;
+
+public static class PdfPageCounter
+{
+    public static int ReadPageCount(string pdfPath)
+    {
+        using var pdf = new PdfDocument(new PdfReader(pdfPath));
+        return pdf.GetNumberOfPages();
+    }
+
+    public static int ReadPageCount(Stream pdfStream)
+    {
+        using var pdf = new PdfDocument(new PdfReader(pdfStream));
+        return pdf.GetNumberOfPages();
+    }
+}

--- a/server.core/Ingest/PdfPageLimitExceededException.cs
+++ b/server.core/Ingest/PdfPageLimitExceededException.cs
@@ -1,0 +1,18 @@
+namespace server.core.Ingest;
+
+public sealed class PdfPageLimitExceededException : InvalidOperationException
+{
+    public PdfPageLimitExceededException(int pageCount, int maxPageCount)
+        : base(BuildMessage(pageCount, maxPageCount))
+    {
+        PageCount = pageCount;
+        MaxPageCount = maxPageCount;
+    }
+
+    public int PageCount { get; }
+
+    public int MaxPageCount { get; }
+
+    public static string BuildMessage(int pageCount, int maxPageCount) =>
+        $"PDFs are temporarily limited to {maxPageCount} pages. This file has {pageCount} pages.";
+}

--- a/server.core/Ingest/PdfProcessor.cs
+++ b/server.core/Ingest/PdfProcessor.cs
@@ -52,6 +52,14 @@ public sealed class PdfProcessor : IPdfProcessor
                 _options.MaxPagesPerChunk,
                 "MaxPagesPerChunk must be > 0.");
         }
+
+        if (_options.MaxPageCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(_options.MaxPageCount),
+                _options.MaxPageCount,
+                "MaxPageCount must be > 0.");
+        }
     }
 
     /// <summary>
@@ -86,6 +94,9 @@ public sealed class PdfProcessor : IPdfProcessor
             // ignore
         }
 
+        var pageCount = ReadPageCount(sourcePath);
+        EnsurePageCountWithinLimit(fileId, pageCount);
+
         // Best-effort: generate a "before" accessibility report on the original uploaded PDF.
         AdobeAccessibilityCheckOutput? beforeAccessibilityReport = null;
         try
@@ -116,8 +127,6 @@ public sealed class PdfProcessor : IPdfProcessor
         {
             _logger.LogWarning(ex, "Failed to generate BEFORE accessibility report for {fileId}", fileId);
         }
-
-        var pageCount = 0;
         string taggedPdfPath;
         if (_options.UseAdobePdfServices)
         {
@@ -135,7 +144,7 @@ public sealed class PdfProcessor : IPdfProcessor
                 beforeAccessibilityReport?.ReportJson,
                 out var retagTriggers,
                 out var retagDecisionError);
-            pageCount = sourceInfo.PageCount > 0 ? sourceInfo.PageCount : 0;
+            pageCount = sourceInfo.PageCount > 0 ? sourceInfo.PageCount : pageCount;
             if (!string.IsNullOrWhiteSpace(retagDecisionError))
             {
                 _logger.LogDebug(
@@ -258,7 +267,6 @@ public sealed class PdfProcessor : IPdfProcessor
         {
             // When Adobe autotagging is disabled, avoid splitting/merging with iText.
             taggedPdfPath = sourcePath;
-            pageCount = TryReadPageCount(sourcePath);
         }
 
         string finalPdfPath;
@@ -343,18 +351,33 @@ public sealed class PdfProcessor : IPdfProcessor
 
     private sealed record SourcePdfInfo(int PageCount, PdfTaggingState TaggingState);
 
-    private static int TryReadPageCount(string pdfPath)
+    private int ReadPageCount(string pdfPath)
     {
         try
         {
-            using var pdf = new PdfDocument(new PdfReader(pdfPath));
-            var pageCount = pdf.GetNumberOfPages();
+            var pageCount = PdfPageCounter.ReadPageCount(pdfPath);
             return pageCount > 0 ? pageCount : 0;
         }
-        catch
+        catch (Exception ex)
         {
-            return 0;
+            throw new InvalidOperationException("Unable to read the uploaded PDF page count.", ex);
         }
+    }
+
+    private void EnsurePageCountWithinLimit(string fileId, int pageCount)
+    {
+        if (pageCount <= _options.MaxPageCount)
+        {
+            return;
+        }
+
+        _logger.LogWarning(
+            "Rejecting {fileId} before Adobe processing: pageCount={pageCount} maxPageCount={maxPageCount}",
+            fileId,
+            pageCount,
+            _options.MaxPageCount);
+
+        throw new PdfPageLimitExceededException(pageCount, _options.MaxPageCount);
     }
 
     private static SourcePdfInfo ReadSourcePdfInfo(
@@ -654,3 +677,5 @@ public sealed class NoopPdfProcessor : IPdfProcessor
         return sb.ToString().Trim();
     }
 }
+
+

--- a/server.core/Ingest/PdfProcessorOptions.cs
+++ b/server.core/Ingest/PdfProcessorOptions.cs
@@ -25,6 +25,11 @@ public sealed class PdfProcessorOptions
     /// </summary>
     public bool AutotagTaggedPdfs { get; set; }
 
+    /// <summary>
+    /// Temporary hard limit to keep oversized PDFs from reaching Adobe-backed processing.
+    /// </summary>
+    public int MaxPageCount { get; set; } = 25;
+
     public int MaxPagesPerChunk { get; set; } = 200;
 
     /// <summary>
@@ -32,3 +37,4 @@ public sealed class PdfProcessorOptions
     /// </summary>
     public string? WorkDirRoot { get; set; }
 }
+

--- a/server/Controllers/FileController.cs
+++ b/server/Controllers/FileController.cs
@@ -39,6 +39,10 @@ public class FileController : ApiControllerBase
                 Status = f.Status,
                 CreatedAt = f.CreatedAt,
                 StatusUpdatedAt = f.StatusUpdatedAt,
+                ProcessingErrorMessage = f.ProcessingAttempts
+                    .OrderByDescending(a => a.AttemptNumber)
+                    .Select(a => a.ErrorMessage)
+                    .FirstOrDefault(),
                 AccessibilityReports = f.AccessibilityReports
                     .OrderByDescending(r => r.GeneratedAt)
                     .Select(r => new AccessibilityReportListItemDto
@@ -72,6 +76,7 @@ public class FileController : ApiControllerBase
         var file = await _dbContext.Files
             .AsNoTracking()
             .Include(f => f.AccessibilityReports)
+            .Include(f => f.ProcessingAttempts)
             .SingleOrDefaultAsync(
                 f => f.FileId == fileId && f.OwnerUserId == userId.Value,
                 cancellationToken);
@@ -120,6 +125,10 @@ public class FileController : ApiControllerBase
             Status = file.Status,
             CreatedAt = file.CreatedAt,
             StatusUpdatedAt = file.StatusUpdatedAt,
+            ProcessingErrorMessage = file.ProcessingAttempts
+                .OrderByDescending(a => a.AttemptNumber)
+                .Select(a => a.ErrorMessage)
+                .FirstOrDefault(),
             AccessibilityReports = reports,
         });
     }
@@ -199,6 +208,7 @@ public class FileController : ApiControllerBase
         public string Status { get; init; } = string.Empty;
         public DateTimeOffset CreatedAt { get; init; }
         public DateTimeOffset StatusUpdatedAt { get; init; }
+        public string? ProcessingErrorMessage { get; init; }
         public List<AccessibilityReportListItemDto> AccessibilityReports { get; set; } = [];
     }
 
@@ -211,6 +221,7 @@ public class FileController : ApiControllerBase
         public string Status { get; init; } = string.Empty;
         public DateTimeOffset CreatedAt { get; init; }
         public DateTimeOffset StatusUpdatedAt { get; init; }
+        public string? ProcessingErrorMessage { get; init; }
         public List<AccessibilityReportDetailsDto> AccessibilityReports { get; set; } = [];
     }
 
@@ -235,3 +246,9 @@ public class FileController : ApiControllerBase
         public JsonElement ReportJson { get; init; }
     }
 }
+
+
+
+
+
+

--- a/server/Controllers/UploadController.cs
+++ b/server/Controllers/UploadController.cs
@@ -1,10 +1,12 @@
 using System.ComponentModel.DataAnnotations;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using server.Helpers;
 using server.Helpers.Validation;
 using server.core.Data;
 using server.core.Domain;
+using server.core.Ingest;
 using server.core.Storage;
 
 namespace Server.Controllers;
@@ -14,15 +16,21 @@ public class UploadController : ApiControllerBase
     private readonly AppDbContext _dbContext;
     private readonly IFileSasService _fileSasService;
     private readonly IIncomingBlobUploadService _blobUploadService;
+    private readonly int _maxPdfPageCount;
 
     // Let the SAS url be valid for 30 min to give ample time to upload.
     private static readonly TimeSpan SasTimeToLive = TimeSpan.FromMinutes(30);
 
-    public UploadController(AppDbContext dbContext, IFileSasService fileSasService, IIncomingBlobUploadService blobUploadService)
+    public UploadController(
+        AppDbContext dbContext,
+        IFileSasService fileSasService,
+        IIncomingBlobUploadService blobUploadService,
+        IConfiguration configuration)
     {
         _dbContext = dbContext;
         _fileSasService = fileSasService;
         _blobUploadService = blobUploadService;
+        _maxPdfPageCount = GetMaxPdfPageCount(configuration);
     }
 
     /// <summary>
@@ -211,6 +219,22 @@ public class UploadController : ApiControllerBase
             contentType = "application/pdf";
         }
 
+        int pageCount;
+        try
+        {
+            await using var validationStream = file.OpenReadStream();
+            pageCount = PdfPageCounter.ReadPageCount(validationStream);
+        }
+        catch (Exception)
+        {
+            return BadRequest("The uploaded file could not be read as a valid PDF.");
+        }
+
+        if (pageCount > _maxPdfPageCount)
+        {
+            return BadRequest(PdfPageLimitExceededException.BuildMessage(pageCount, _maxPdfPageCount));
+        }
+
         var now = DateTimeOffset.UtcNow;
         var fileRecord = new FileRecord
         {
@@ -219,7 +243,7 @@ public class UploadController : ApiControllerBase
             OriginalFileName = originalFileName,
             ContentType = contentType,
             SizeBytes = file.Length,
-            PageCount = 0,
+            PageCount = pageCount,
             Status = FileRecord.Statuses.Created,
             CreatedAt = now,
             StatusUpdatedAt = now,
@@ -280,6 +304,21 @@ public class UploadController : ApiControllerBase
         }
 
         return fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int GetMaxPdfPageCount(IConfiguration configuration)
+    {
+        var maxPdfPageCount =
+            configuration.GetValue<int?>("Ingest:PdfMaxPageCount")
+            ?? configuration.GetValue<int?>("INGEST_PDF_MAX_PAGE_COUNT")
+            ?? 25;
+
+        if (maxPdfPageCount <= 0)
+        {
+            throw new InvalidOperationException("Ingest:PdfMaxPageCount must be greater than 0.");
+        }
+
+        return maxPdfPageCount;
     }
 
     public sealed class CreateUploadSasRequest

--- a/tests/server.tests/Controllers/FileControllerTests.cs
+++ b/tests/server.tests/Controllers/FileControllerTests.cs
@@ -81,6 +81,74 @@ public class FileControllerTests
     }
 
     [Fact]
+    public async Task List_when_file_failed_returns_latest_processing_error_message()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var user = new User
+        {
+            UserId = 1,
+            EntraObjectId = Guid.NewGuid(),
+            Email = "test@example.com",
+            DisplayName = "Test User",
+        };
+        ctx.Users.Add(user);
+
+        var fileId = Guid.NewGuid();
+        ctx.Files.Add(new FileRecord
+        {
+            FileId = fileId,
+            OwnerUserId = user.UserId,
+            OwnerUser = user,
+            OriginalFileName = "test.pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 123,
+            Status = FileRecord.Statuses.Failed,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            StatusUpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            ProcessingAttempts =
+            [
+                new FileProcessingAttempt
+                {
+                    AttemptNumber = 1,
+                    Trigger = FileProcessingAttempt.Triggers.Upload,
+                    Outcome = FileProcessingAttempt.Outcomes.Failed,
+                    StartedAt = DateTimeOffset.UtcNow.AddMinutes(-4),
+                    FinishedAt = DateTimeOffset.UtcNow.AddMinutes(-4),
+                    ErrorMessage = "Old failure",
+                },
+                new FileProcessingAttempt
+                {
+                    AttemptNumber = 2,
+                    Trigger = FileProcessingAttempt.Triggers.Retry,
+                    Outcome = FileProcessingAttempt.Outcomes.Failed,
+                    StartedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                    FinishedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                    ErrorMessage = "PDFs are temporarily limited to 25 pages.",
+                },
+            ],
+        });
+
+        await ctx.SaveChangesAsync();
+
+        var controller = new FileController(ctx);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = BuildUser(user.UserId),
+            },
+        };
+
+        var result = await controller.List(CancellationToken.None);
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var ok = (OkObjectResult)result.Result!;
+        var dto = ok.Value.Should().BeAssignableTo<List<FileController.FileListItemDto>>().Subject.Single();
+        dto.ProcessingErrorMessage.Should().Be("PDFs are temporarily limited to 25 pages.");
+    }
+
+    [Fact]
     public async Task GetById_when_owned_returns_file_and_reports()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
@@ -151,6 +219,7 @@ public class FileControllerTests
         var dto = (FileController.FileDetailsDto)ok.Value!;
         dto.FileId.Should().Be(fileId);
         dto.OriginalFileName.Should().Be("test.pdf");
+        dto.ProcessingErrorMessage.Should().BeNull();
         dto.AccessibilityReports.Should().HaveCount(2);
 
         dto.AccessibilityReports.Select(r => r.Stage).Should().Contain(new[]
@@ -174,4 +243,8 @@ public class FileControllerTests
         return new ClaimsPrincipal(identity);
     }
 }
+
+
+
+
 

--- a/tests/server.tests/Controllers/UploadControllerTests.cs
+++ b/tests/server.tests/Controllers/UploadControllerTests.cs
@@ -1,12 +1,15 @@
 using System.Security.Claims;
 using FluentAssertions;
+using iText.Kernel.Pdf;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Server.Controllers;
 using server.Helpers;
 using server.core.Data;
 using server.core.Domain;
+using server.core.Ingest;
 using server.core.Storage;
 using Server.Tests;
 
@@ -45,7 +48,11 @@ public class UploadControllerTests
 
         await ctx.SaveChangesAsync();
 
-        var controller = new UploadController(ctx, new UnusedFileSasService(), new UnusedBlobUploadService());
+        var controller = new UploadController(
+            ctx,
+            new UnusedFileSasService(),
+            new UnusedBlobUploadService(),
+            BuildConfiguration());
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext
@@ -62,12 +69,83 @@ public class UploadControllerTests
         updated.StatusUpdatedAt.Should().BeAfter(createdAt);
     }
 
+    [Fact]
+    public async Task DirectUpload_WhenPdfExceedsConfiguredPageLimit_ReturnsBadRequest()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var user = new User
+        {
+            UserId = 1,
+            EntraObjectId = Guid.NewGuid(),
+            Email = "test@example.com",
+            DisplayName = "Test User",
+        };
+        ctx.Users.Add(user);
+        await ctx.SaveChangesAsync();
+
+        var blobUpload = new RecordingBlobUploadService();
+        var controller = new UploadController(
+            ctx,
+            new UnusedFileSasService(),
+            blobUpload,
+            BuildConfiguration(("Ingest:PdfMaxPageCount", "25")));
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = BuildUser(user.UserId),
+            },
+        };
+
+        var pdfBytes = CreatePdfBytes(pageCount: 26);
+        IFormFile file = new FormFile(new MemoryStream(pdfBytes), 0, pdfBytes.Length, "file", "too-many-pages.pdf")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/pdf",
+        };
+
+        var result = await controller.DirectUpload(file, CancellationToken.None);
+
+        var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().Be(PdfPageLimitExceededException.BuildMessage(26, 25));
+        blobUpload.Calls.Should().Be(0);
+        ctx.Files.Count().Should().Be(0);
+    }
+
     private static ClaimsPrincipal BuildUser(long userId)
     {
         var identity = new ClaimsIdentity(
             new[] { new Claim(ClaimsPrincipalExtensions.AppUserIdClaimType, userId.ToString()) },
             authenticationType: "test");
         return new ClaimsPrincipal(identity);
+    }
+
+    private static IConfiguration BuildConfiguration(params (string Key, string Value)[] values)
+    {
+        IEnumerable<KeyValuePair<string, string?>> data = values
+            .Select(x => new KeyValuePair<string, string?>(x.Key, x.Value));
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(data)
+            .Build();
+    }
+
+    private static byte[] CreatePdfBytes(int pageCount)
+    {
+        using var stream = new MemoryStream();
+        var writer = new PdfWriter(stream);
+        writer.SetCloseStream(false);
+
+        using (var pdf = new PdfDocument(writer))
+        {
+            for (var i = 0; i < pageCount; i++)
+            {
+                pdf.AddNewPage();
+            }
+        }
+
+        return stream.ToArray();
     }
 
     private sealed class UnusedFileSasService : IFileSasService
@@ -84,4 +162,17 @@ public class UploadControllerTests
         public Task UploadAsync(Guid fileId, Stream content, string contentType, CancellationToken cancellationToken) =>
             throw new InvalidOperationException("Not used by this test.");
     }
+
+    private sealed class RecordingBlobUploadService : IIncomingBlobUploadService
+    {
+        public int Calls { get; private set; }
+
+        public Task UploadAsync(Guid fileId, Stream content, string contentType, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.CompletedTask;
+        }
+    }
 }
+
+

--- a/tests/server.tests/Ingest/FileIngestProcessorTests.cs
+++ b/tests/server.tests/Ingest/FileIngestProcessorTests.cs
@@ -193,6 +193,76 @@ public class FileIngestProcessorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WhenPdfProcessorThrowsPageLimitExceeded_MarksAttemptAndFileFailed()
+    {
+        var fileId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"ingest_{Guid.NewGuid():N}")
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        await using (var seed = new AppDbContext(options))
+        {
+            seed.Database.EnsureCreated();
+
+            var user = new User
+            {
+                UserId = 1,
+                EntraObjectId = Guid.NewGuid(),
+            };
+
+            seed.Users.Add(user);
+            seed.Files.Add(new FileRecord
+            {
+                FileId = fileId,
+                OwnerUserId = user.UserId,
+                OwnerUser = user,
+                OriginalFileName = "abc123.pdf",
+                ContentType = "application/pdf",
+                SizeBytes = 123,
+                Status = FileRecord.Statuses.Queued,
+                CreatedAt = DateTimeOffset.UtcNow,
+                StatusUpdatedAt = DateTimeOffset.UtcNow,
+            });
+
+            await seed.SaveChangesAsync();
+        }
+
+        var dbContextFactory = new InMemoryDbContextFactory(options);
+        var opener = new FakeBlobStreamOpener();
+        var pdf = new ThrowingPdfProcessor(new PdfPageLimitExceededException(26, 25));
+        var blobStorage = new FakeBlobStorage();
+        var configuration = new ConfigurationBuilder().Build();
+        using var loggerFactory = LoggerFactory.Create(_ => { });
+
+        var sut = new FileIngestProcessor(
+            dbContextFactory,
+            opener,
+            pdf,
+            blobStorage,
+            configuration,
+            loggerFactory.CreateLogger<FileIngestProcessor>());
+
+        var request = new BlobIngestRequest(
+            new Uri("https://example.blob.core.windows.net/incoming/abc123.pdf"),
+            "incoming",
+            "abc123.pdf",
+            fileId.ToString());
+
+        Func<Task> act = () => sut.ProcessAsync(request, CancellationToken.None);
+        await act.Should().ThrowAsync<PdfPageLimitExceededException>();
+
+        await using var verify = new AppDbContext(options);
+        var file = await verify.Files.SingleAsync(x => x.FileId == fileId);
+        file.Status.Should().Be(FileRecord.Statuses.Failed);
+
+        var attempt = await verify.FileProcessingAttempts.SingleAsync(x => x.FileId == fileId);
+        attempt.Outcome.Should().Be(FileProcessingAttempt.Outcomes.Failed);
+        attempt.ErrorCode.Should().Be(nameof(PdfPageLimitExceededException));
+        attempt.ErrorMessage.Should().Contain("temporarily limited to 25 pages");
+    }
+
+    [Fact]
     public async Task ProcessAsync_WhenFileRecordMissing_ThrowsBeforeOpeningBlob()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
@@ -324,9 +394,21 @@ public class FileIngestProcessorTests
 
     private sealed class ThrowingPdfProcessor : IPdfProcessor
     {
+        private readonly Exception _exception;
+
+        public ThrowingPdfProcessor()
+            : this(new InvalidOperationException("boom"))
+        {
+        }
+
+        public ThrowingPdfProcessor(Exception exception)
+        {
+            _exception = exception;
+        }
+
         public Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
         {
-            throw new InvalidOperationException("boom");
+            throw _exception;
         }
     }
 
@@ -352,3 +434,5 @@ public class FileIngestProcessorTests
         }
     }
 }
+
+

--- a/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
+++ b/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
@@ -164,6 +164,50 @@ public sealed class PdfProcessorIntegrationTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WhenPdfExceedsMaxPageCount_ThrowsBeforeAdobeRuns()
+    {
+        var fileId = $"pdf-over-limit-test-{Guid.NewGuid():N}";
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", fileId);
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTestPdf(inputPdfPath, pageCount: 26);
+            await using var inputStream = File.OpenRead(inputPdfPath);
+
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+            var adobe = new CapturingAdobePdfServices();
+            var remediation = new NoopPdfRemediationProcessor();
+            var options = Options.Create(new PdfProcessorOptions
+            {
+                UseAdobePdfServices = true,
+                UsePdfRemediationProcessor = false,
+                MaxPageCount = 25,
+                MaxPagesPerChunk = 200,
+                WorkDirRoot = runRoot
+            });
+
+            var sut = new PdfProcessor(adobe, remediation, options, loggerFactory.CreateLogger<PdfProcessor>());
+
+            var act = () => sut.ProcessAsync(fileId, inputStream, CancellationToken.None);
+            var error = await act.Should().ThrowAsync<PdfPageLimitExceededException>();
+
+            error.Which.PageCount.Should().Be(26);
+            error.Which.MaxPageCount.Should().Be(25);
+            adobe.Calls.Should().BeEmpty();
+            adobe.AccessibilityCheckCalls.Should().Be(0);
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ProcessAsync_WithAdobeEnabledAndTaggedPdf_SkipsAutotagByDefault()
     {
         var fileId = $"pdf-tagged-adobe-skip-test-{Guid.NewGuid():N}";
@@ -258,6 +302,7 @@ public sealed class PdfProcessorIntegrationTests
     private sealed class CapturingAdobePdfServices : IAdobePdfServices
     {
         public List<AdobeCall> Calls { get; } = [];
+        public int AccessibilityCheckCalls { get; private set; }
 
         public async Task<AdobeAutotagOutput> AutotagPdfAsync(
             string inputPdfPath,
@@ -288,6 +333,7 @@ public sealed class PdfProcessorIntegrationTests
             int? pageEnd,
             CancellationToken cancellationToken)
         {
+            AccessibilityCheckCalls++;
             _ = inputPdfPath;
             _ = outputPdfPath;
             _ = outputReportPath;
@@ -368,3 +414,6 @@ public sealed class PdfProcessorIntegrationTests
         return pdf.GetNumberOfPages();
     }
 }
+
+
+

--- a/workers/function.ingest/Program.cs
+++ b/workers/function.ingest/Program.cs
@@ -42,6 +42,10 @@ builder.Services.AddFileIngest(o =>
 
     o.UseAdobePdfServices = true;
     o.UsePdfRemediationProcessor = true;
+    o.PdfMaxPageCount =
+        builder.Configuration.GetValue<int?>("Ingest:PdfMaxPageCount")
+        ?? builder.Configuration.GetValue<int?>("INGEST_PDF_MAX_PAGE_COUNT")
+        ?? 25;
     // Default: skip autotagging for already-tagged PDFs (e.g., Office exports) unless explicitly enabled.
     o.AutotagTaggedPdfs =
         builder.Configuration.GetValue<bool>("Ingest:AutotagTaggedPdfs")
@@ -57,3 +61,4 @@ builder.Services.AddApplicationInsightsTelemetryWorkerService();
 builder.Services.ConfigureFunctionsApplicationInsights();
 
 builder.Build().Run();
+


### PR DESCRIPTION
Introduces a configurable limit (defaulting to 25 pages) to prevent oversized PDFs from reaching Adobe-backed processing services. Validation is performed during both the initial upload and the ingestion phase, with custom exception handling to provide clear feedback when a file exceeds the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable PDF page-limit (default 25) enforced at upload; oversized PDFs are rejected.
  * Detected PDF page counts are stored with file records.
  * UI shows per-file processing error messages and a "Processing failed" indicator.

* **Tests**
  * Added unit and integration tests for page-limit rejection, early enforcement (pre-external processing), and propagation/display of processing error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->