### PR TITLE
Adds failure reasons to PDF activity card

### DIFF
--- a/client/src/components/pdf/PdfActivityCard.tsx
+++ b/client/src/components/pdf/PdfActivityCard.tsx
@@ -13,9 +13,17 @@ import {
   TrashIcon,
   DocumentChartBarIcon,
 } from '@heroicons/react/24/outline';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 const MAX_BATCH_SIZE = 50;
+
+type FailureTooltipState = {
+  anchor: HTMLSpanElement;
+  fileId: string;
+  message: string;
+};
+
 
 export type PdfActivityCardProps = {
   activeUploadCount: number;
@@ -46,6 +54,12 @@ export function PdfActivityCard({
   const archiveMutation = useArchiveFilesMutation();
   const undeleteMutation = useUndeleteFilesMutation();
   const zipMutation = useDownloadFilesAsZipMutation();
+  const [failureTooltip, setFailureTooltip] =
+    useState<FailureTooltipState | null>(null);
+  const [failureTooltipPosition, setFailureTooltipPosition] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
 
   const visibleFiles = files?.filter((f) => !hiddenIds.has(f.fileId));
   const filteredFiles = visibleFiles?.filter((f) =>
@@ -200,6 +214,54 @@ export function PdfActivityCard({
       },
     });
   }, [recentlyDeletedIds, undeleteMutation]);
+
+  const closeFailureTooltip = useCallback(() => {
+    setFailureTooltip(null);
+  }, []);
+
+  const openFailureTooltip = useCallback(
+    (fileId: string, message: string, anchor: HTMLSpanElement) => {
+      setFailureTooltip({ anchor, fileId, message });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!failureTooltip) {
+      setFailureTooltipPosition(null);
+      return;
+    }
+
+    const updatePosition = () => {
+      if (!failureTooltip.anchor.isConnected) {
+        setFailureTooltip(null);
+        return;
+      }
+
+      const rect = failureTooltip.anchor.getBoundingClientRect();
+      const tooltipHalfWidth = 192;
+      const viewportPadding = 16;
+      const left = Math.min(
+        Math.max(rect.left + rect.width / 2, viewportPadding + tooltipHalfWidth),
+        window.innerWidth - viewportPadding - tooltipHalfWidth
+      );
+
+      setFailureTooltipPosition({
+        left,
+        top: rect.bottom + 12,
+      });
+    };
+
+    updatePosition();
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [failureTooltip]);
 
   return (
     <div className="card bg-base-100 shadow">
@@ -398,6 +460,10 @@ export function PdfActivityCard({
                     typeof afterIssues === 'number'
                       ? beforeIssues - afterIssues
                       : null;
+                  const isFailed = file.status.toLowerCase() === 'failed';
+                  const failureReason =
+                    file.latestFailureReason?.trim() ||
+                    'No additional details were provided.';
 
                   return (
                     <tr className="group" key={file.fileId}>
@@ -424,9 +490,39 @@ export function PdfActivityCard({
                       <td>
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
-                            <span className="badge badge-primary badge-soft">
-                              {file.status}
-                            </span>
+                            {isFailed ? (
+                              <span
+                                aria-describedby={
+                                  failureTooltip?.fileId === file.fileId
+                                    ? `failure-reason-${file.fileId}`
+                                    : undefined
+                                }
+                                className="badge badge-error badge-soft cursor-help"
+                                onBlur={closeFailureTooltip}
+                                onFocus={(e) =>
+                                  openFailureTooltip(
+                                    file.fileId,
+                                    failureReason,
+                                    e.currentTarget
+                                  )
+                                }
+                                onMouseEnter={(e) =>
+                                  openFailureTooltip(
+                                    file.fileId,
+                                    failureReason,
+                                    e.currentTarget
+                                  )
+                                }
+                                onMouseLeave={closeFailureTooltip}
+                                tabIndex={0}
+                              >
+                                {file.status}
+                              </span>
+                            ) : (
+                              <span className="badge badge-primary badge-soft">
+                                {file.status}
+                              </span>
+                            )}
                           </div>
 
                           {recentlyCompletedByFileId[file.fileId] ? (
@@ -453,7 +549,11 @@ export function PdfActivityCard({
 
                       {/* Report */}
                       <td className="text-base">
-                        {file.status !== 'Completed' ? (
+                        {isFailed ? (
+                          <span className="font-medium text-error">
+                            Processing failed
+                          </span>
+                        ) : file.status !== 'Completed' ? (
                           <span className="text-base-content/70">—</span>
                         ) : !afterReport ? (
                           <span className="text-base-content/70">
@@ -578,6 +678,33 @@ export function PdfActivityCard({
           </button>
         </form>
       </dialog>
+
+      {failureTooltip &&
+      failureTooltipPosition &&
+      typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              className="pointer-events-none fixed z-50 w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-error/20 bg-base-100 p-4 text-left shadow-xl ring-1 ring-base-content/5"
+              id={`failure-reason-${failureTooltip.fileId}`}
+              role="tooltip"
+              style={{
+                left: failureTooltipPosition.left,
+                top: failureTooltipPosition.top,
+              }}
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-error">
+                Failure reason
+              </p>
+              <p className="mt-2 text-sm leading-6 text-base-content/80">
+                {failureTooltip.message}
+              </p>
+            </div>,
+            document.body
+          )
+        : null}
     </div>
   );
 }
+
+
+

--- a/client/src/components/pdf/PdfActivityCard.tsx
+++ b/client/src/components/pdf/PdfActivityCard.tsx
@@ -6,6 +6,7 @@ import {
   useUndeleteFilesMutation,
 } from '@/queries/files.ts';
 import { formatBytes, formatDateTime } from '@/lib/format.ts';
+import { PdfFailureStatusBadge } from '@/components/pdf/PdfFailureStatusBadge.tsx';
 import { Link } from '@tanstack/react-router';
 import { ArrowDownTrayIcon } from '@heroicons/react/24/solid';
 import {
@@ -13,16 +14,9 @@ import {
   TrashIcon,
   DocumentChartBarIcon,
 } from '@heroicons/react/24/outline';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 const MAX_BATCH_SIZE = 50;
-
-type FailureTooltipState = {
-  anchor: HTMLSpanElement;
-  fileId: string;
-  message: string;
-};
 
 
 export type PdfActivityCardProps = {
@@ -48,19 +42,12 @@ export function PdfActivityCard({
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
   const [archiveError, setArchiveError] = useState<string | null>(null);
   const confirmDialogRef = useRef<HTMLDialogElement>(null);
-  const failureTooltipRef = useRef<HTMLDivElement>(null);
   const [pendingBulkIds, setPendingBulkIds] = useState<string[]>([]);
   const [recentlyDeletedIds, setRecentlyDeletedIds] = useState<string[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const archiveMutation = useArchiveFilesMutation();
   const undeleteMutation = useUndeleteFilesMutation();
   const zipMutation = useDownloadFilesAsZipMutation();
-  const [failureTooltip, setFailureTooltip] =
-    useState<FailureTooltipState | null>(null);
-  const [failureTooltipPosition, setFailureTooltipPosition] = useState<{
-    left: number;
-    top: number;
-  } | null>(null);
 
   const visibleFiles = files?.filter((f) => !hiddenIds.has(f.fileId));
   const filteredFiles = visibleFiles?.filter((f) =>
@@ -216,60 +203,6 @@ export function PdfActivityCard({
     });
   }, [recentlyDeletedIds, undeleteMutation]);
 
-  const closeFailureTooltip = useCallback(() => {
-    setFailureTooltip(null);
-  }, []);
-
-  const openFailureTooltip = useCallback(
-    (fileId: string, message: string, anchor: HTMLSpanElement) => {
-      setFailureTooltip({ anchor, fileId, message });
-    },
-    []
-  );
-
-  useEffect(() => {
-    if (!failureTooltip) {
-      setFailureTooltipPosition(null);
-      return;
-    }
-
-    const updatePosition = () => {
-      if (!failureTooltip.anchor.isConnected) {
-        setFailureTooltip(null);
-        return;
-      }
-
-      const rect = failureTooltip.anchor.getBoundingClientRect();
-      const viewportPadding = 16;
-      const fallbackTooltipWidth = Math.min(
-        320,
-        Math.max(0, window.innerWidth - viewportPadding * 2)
-      );
-      const tooltipWidth =
-        failureTooltipRef.current?.getBoundingClientRect().width ??
-        fallbackTooltipWidth;
-      const tooltipHalfWidth = tooltipWidth / 2;
-      const left = Math.min(
-        Math.max(rect.left + rect.width / 2, viewportPadding + tooltipHalfWidth),
-        window.innerWidth - viewportPadding - tooltipHalfWidth
-      );
-
-      setFailureTooltipPosition({
-        left,
-        top: rect.bottom + 12,
-      });
-    };
-
-    updatePosition();
-
-    window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
-
-    return () => {
-      window.removeEventListener('resize', updatePosition);
-      window.removeEventListener('scroll', updatePosition, true);
-    };
-  }, [failureTooltip]);
 
   return (
     <div className="card bg-base-100 shadow">
@@ -499,33 +432,11 @@ export function PdfActivityCard({
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
                             {isFailed ? (
-                              <span
-                                aria-describedby={
-                                  failureTooltip?.fileId === file.fileId
-                                    ? `failure-reason-${file.fileId}`
-                                    : undefined
-                                }
-                                className="badge badge-error badge-soft cursor-help"
-                                onBlur={closeFailureTooltip}
-                                onFocus={(e) =>
-                                  openFailureTooltip(
-                                    file.fileId,
-                                    failureReason,
-                                    e.currentTarget
-                                  )
-                                }
-                                onMouseEnter={(e) =>
-                                  openFailureTooltip(
-                                    file.fileId,
-                                    failureReason,
-                                    e.currentTarget
-                                  )
-                                }
-                                onMouseLeave={closeFailureTooltip}
-                                tabIndex={0}
-                              >
-                                {file.status}
-                              </span>
+                              <PdfFailureStatusBadge
+                                failureReason={failureReason}
+                                fileId={file.fileId}
+                                status={file.status}
+                              />
                             ) : (
                               <span className="badge badge-primary badge-soft">
                                 {file.status}
@@ -686,33 +597,13 @@ export function PdfActivityCard({
           </button>
         </form>
       </dialog>
-
-      {failureTooltip && typeof document !== 'undefined'
-        ? createPortal(
-            <div
-              className="pointer-events-none fixed z-50 w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-error/20 bg-base-100 p-4 text-left shadow-xl ring-1 ring-base-content/5"
-              id={`failure-reason-${failureTooltip.fileId}`}
-              ref={failureTooltipRef}
-              role="tooltip"
-              style={{
-                left: failureTooltipPosition?.left ?? 0,
-                top: failureTooltipPosition?.top ?? 0,
-                visibility: failureTooltipPosition ? 'visible' : 'hidden',
-              }}
-            >
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-error">
-                Failure reason
-              </p>
-              <p className="mt-2 text-sm leading-6 text-base-content/80">
-                {failureTooltip.message}
-              </p>
-            </div>,
-            document.body
-          )
-        : null}
     </div>
   );
 }
+
+
+
+
 
 
 

--- a/client/src/components/pdf/PdfActivityCard.tsx
+++ b/client/src/components/pdf/PdfActivityCard.tsx
@@ -48,6 +48,7 @@ export function PdfActivityCard({
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
   const [archiveError, setArchiveError] = useState<string | null>(null);
   const confirmDialogRef = useRef<HTMLDialogElement>(null);
+  const failureTooltipRef = useRef<HTMLDivElement>(null);
   const [pendingBulkIds, setPendingBulkIds] = useState<string[]>([]);
   const [recentlyDeletedIds, setRecentlyDeletedIds] = useState<string[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -239,8 +240,15 @@ export function PdfActivityCard({
       }
 
       const rect = failureTooltip.anchor.getBoundingClientRect();
-      const tooltipHalfWidth = 192;
       const viewportPadding = 16;
+      const fallbackTooltipWidth = Math.min(
+        320,
+        Math.max(0, window.innerWidth - viewportPadding * 2)
+      );
+      const tooltipWidth =
+        failureTooltipRef.current?.getBoundingClientRect().width ??
+        fallbackTooltipWidth;
+      const tooltipHalfWidth = tooltipWidth / 2;
       const left = Math.min(
         Math.max(rect.left + rect.width / 2, viewportPadding + tooltipHalfWidth),
         window.innerWidth - viewportPadding - tooltipHalfWidth
@@ -679,17 +687,17 @@ export function PdfActivityCard({
         </form>
       </dialog>
 
-      {failureTooltip &&
-      failureTooltipPosition &&
-      typeof document !== 'undefined'
+      {failureTooltip && typeof document !== 'undefined'
         ? createPortal(
             <div
               className="pointer-events-none fixed z-50 w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-error/20 bg-base-100 p-4 text-left shadow-xl ring-1 ring-base-content/5"
               id={`failure-reason-${failureTooltip.fileId}`}
+              ref={failureTooltipRef}
               role="tooltip"
               style={{
-                left: failureTooltipPosition.left,
-                top: failureTooltipPosition.top,
+                left: failureTooltipPosition?.left ?? 0,
+                top: failureTooltipPosition?.top ?? 0,
+                visibility: failureTooltipPosition ? 'visible' : 'hidden',
               }}
             >
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-error">
@@ -705,6 +713,9 @@ export function PdfActivityCard({
     </div>
   );
 }
+
+
+
 
 
 

--- a/client/src/components/pdf/PdfFailureStatusBadge.tsx
+++ b/client/src/components/pdf/PdfFailureStatusBadge.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type FailureTooltipState = {
+  anchor: HTMLSpanElement;
+  fileId: string;
+  message: string;
+};
+
+type PdfFailureStatusBadgeProps = {
+  failureReason: string;
+  fileId: string;
+  status: string;
+};
+
+export function PdfFailureStatusBadge({
+  failureReason,
+  fileId,
+  status,
+}: PdfFailureStatusBadgeProps) {
+  const failureTooltipRef = useRef<HTMLDivElement>(null);
+  const [failureTooltip, setFailureTooltip] =
+    useState<FailureTooltipState | null>(null);
+  const [failureTooltipPosition, setFailureTooltipPosition] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
+
+  const closeFailureTooltip = useCallback(() => {
+    setFailureTooltip(null);
+  }, []);
+
+  const openFailureTooltip = useCallback(
+    (message: string, anchor: HTMLSpanElement) => {
+      setFailureTooltip({ anchor, fileId, message });
+    },
+    [fileId]
+  );
+
+  useEffect(() => {
+    if (!failureTooltip) {
+      setFailureTooltipPosition(null);
+      return;
+    }
+
+    const updatePosition = () => {
+      if (!failureTooltip.anchor.isConnected) {
+        setFailureTooltip(null);
+        return;
+      }
+
+      const rect = failureTooltip.anchor.getBoundingClientRect();
+      const viewportPadding = 16;
+      const fallbackTooltipWidth = Math.min(
+        320,
+        Math.max(0, window.innerWidth - viewportPadding * 2)
+      );
+      const tooltipWidth =
+        failureTooltipRef.current?.getBoundingClientRect().width ??
+        fallbackTooltipWidth;
+      const tooltipHalfWidth = tooltipWidth / 2;
+      const left = Math.min(
+        Math.max(rect.left + rect.width / 2, viewportPadding + tooltipHalfWidth),
+        window.innerWidth - viewportPadding - tooltipHalfWidth
+      );
+
+      setFailureTooltipPosition({
+        left,
+        top: rect.bottom + 12,
+      });
+    };
+
+    updatePosition();
+
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [failureTooltip]);
+
+  return (
+    <>
+      <span
+        aria-describedby={
+          failureTooltip ? `failure-reason-${failureTooltip.fileId}` : undefined
+        }
+        className="badge badge-error badge-soft cursor-help"
+        onBlur={closeFailureTooltip}
+        onFocus={(e) => openFailureTooltip(failureReason, e.currentTarget)}
+        onMouseEnter={(e) => openFailureTooltip(failureReason, e.currentTarget)}
+        onMouseLeave={closeFailureTooltip}
+        tabIndex={0}
+      >
+        {status}
+      </span>
+
+      {failureTooltip && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              className="pointer-events-none fixed z-50 w-80 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-error/20 bg-base-100 p-4 text-left shadow-xl ring-1 ring-base-content/5"
+              id={`failure-reason-${failureTooltip.fileId}`}
+              ref={failureTooltipRef}
+              role="tooltip"
+              style={{
+                left: failureTooltipPosition?.left ?? 0,
+                top: failureTooltipPosition?.top ?? 0,
+                visibility: failureTooltipPosition ? 'visible' : 'hidden',
+              }}
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-error">
+                Failure reason
+              </p>
+              <p className="mt-2 text-sm leading-6 text-base-content/80">
+                {failureTooltip.message}
+              </p>
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  );
+}

--- a/client/src/queries/files.ts
+++ b/client/src/queries/files.ts
@@ -33,6 +33,7 @@ export type UserFile = {
   sizeBytes: number;
   status: string;
   statusUpdatedAt: string;
+  latestFailureReason?: string | null;
 };
 
 export type UserFileDetails = Omit<UserFile, 'accessibilityReports'> & {
@@ -145,3 +146,4 @@ export function useDownloadFilesAsZipMutation() {
     mutationFn: (fileIds: string[]) => downloadFilesAsZip(fileIds),
   });
 }
+

--- a/server/Controllers/FileController.cs
+++ b/server/Controllers/FileController.cs
@@ -39,6 +39,11 @@ public class FileController : ApiControllerBase
                 Status = f.Status,
                 CreatedAt = f.CreatedAt,
                 StatusUpdatedAt = f.StatusUpdatedAt,
+                LatestFailureReason = f.ProcessingAttempts
+                    .Where(a => a.Outcome == FileProcessingAttempt.Outcomes.Failed)
+                    .OrderByDescending(a => a.AttemptNumber)
+                    .Select(a => a.ErrorMessage)
+                    .FirstOrDefault(),
                 AccessibilityReports = f.AccessibilityReports
                     .OrderByDescending(r => r.GeneratedAt)
                     .Select(r => new AccessibilityReportListItemDto
@@ -72,6 +77,7 @@ public class FileController : ApiControllerBase
         var file = await _dbContext.Files
             .AsNoTracking()
             .Include(f => f.AccessibilityReports)
+            .Include(f => f.ProcessingAttempts)
             .SingleOrDefaultAsync(
                 f => f.FileId == fileId && f.OwnerUserId == userId.Value,
                 cancellationToken);
@@ -120,6 +126,11 @@ public class FileController : ApiControllerBase
             Status = file.Status,
             CreatedAt = file.CreatedAt,
             StatusUpdatedAt = file.StatusUpdatedAt,
+            LatestFailureReason = file.ProcessingAttempts
+                .Where(a => a.Outcome == FileProcessingAttempt.Outcomes.Failed)
+                .OrderByDescending(a => a.AttemptNumber)
+                .Select(a => a.ErrorMessage)
+                .FirstOrDefault(),
             AccessibilityReports = reports,
         });
     }
@@ -199,6 +210,7 @@ public class FileController : ApiControllerBase
         public string Status { get; init; } = string.Empty;
         public DateTimeOffset CreatedAt { get; init; }
         public DateTimeOffset StatusUpdatedAt { get; init; }
+        public string? LatestFailureReason { get; init; }
         public List<AccessibilityReportListItemDto> AccessibilityReports { get; set; } = [];
     }
 
@@ -211,6 +223,7 @@ public class FileController : ApiControllerBase
         public string Status { get; init; } = string.Empty;
         public DateTimeOffset CreatedAt { get; init; }
         public DateTimeOffset StatusUpdatedAt { get; init; }
+        public string? LatestFailureReason { get; init; }
         public List<AccessibilityReportDetailsDto> AccessibilityReports { get; set; } = [];
     }
 
@@ -235,3 +248,4 @@ public class FileController : ApiControllerBase
         public JsonElement ReportJson { get; init; }
     }
 }
+

--- a/tests/server.tests/Controllers/FileControllerTests.cs
+++ b/tests/server.tests/Controllers/FileControllerTests.cs
@@ -166,6 +166,78 @@ public class FileControllerTests
         after.ReportJson.GetProperty("Summary").GetProperty("Passed").GetInt32().Should().Be(2);
     }
 
+    [Fact]
+    public async Task List_when_file_failed_returns_latest_failure_reason()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var user = new User
+        {
+            UserId = 1,
+            EntraObjectId = Guid.NewGuid(),
+            Email = "test@example.com",
+            DisplayName = "Test User",
+        };
+        ctx.Users.Add(user);
+
+        var fileId = Guid.NewGuid();
+        ctx.Files.Add(new FileRecord
+        {
+            FileId = fileId,
+            OwnerUserId = user.UserId,
+            OwnerUser = user,
+            OriginalFileName = "failed.pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 123,
+            Status = FileRecord.Statuses.Failed,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            StatusUpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        });
+
+        ctx.FileProcessingAttempts.AddRange(
+            new FileProcessingAttempt
+            {
+                FileId = fileId,
+                AttemptNumber = 1,
+                Trigger = FileProcessingAttempt.Triggers.Upload,
+                Outcome = FileProcessingAttempt.Outcomes.Failed,
+                StartedAt = DateTimeOffset.UtcNow.AddMinutes(-4),
+                FinishedAt = DateTimeOffset.UtcNow.AddMinutes(-4),
+                ErrorMessage = "older failure",
+            },
+            new FileProcessingAttempt
+            {
+                FileId = fileId,
+                AttemptNumber = 2,
+                Trigger = FileProcessingAttempt.Triggers.Retry,
+                Outcome = FileProcessingAttempt.Outcomes.Failed,
+                StartedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                FinishedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                ErrorMessage = "latest failure",
+            });
+
+        await ctx.SaveChangesAsync();
+
+        var controller = new FileController(ctx);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = BuildUser(user.UserId),
+            },
+        };
+
+        var result = await controller.List(CancellationToken.None);
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var ok = (OkObjectResult)result.Result!;
+        ok.Value.Should().BeAssignableTo<List<FileController.FileListItemDto>>();
+
+        var dto = ((List<FileController.FileListItemDto>)ok.Value!).Single();
+        dto.FileId.Should().Be(fileId);
+        dto.LatestFailureReason.Should().Be("latest failure");
+    }
+
     private static ClaimsPrincipal BuildUser(long userId)
     {
         var identity = new ClaimsIdentity(


### PR DESCRIPTION
Shows a tooltip with the specific error message when a file processing task fails. This allows users to understand why a PDF could not be processed by surfacing the error message from the latest failed processing attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failure reason tooltips shown on hover/focus of failed file status badges, with accessible portal rendering and keyboard focus support.
  * Visual flow for failed files: status now shows a failure badge and the report column displays a "Processing failed" message.
  * API now returns the latest failure reason for files in list and detail responses.
* **Tests**
  * Added test verifying the list endpoint returns the most recent failure message for failed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->