### PR TITLE
Uses unique work directories for PDF processing attempts

### DIFF
--- a/server.core/Ingest/AdobePdfServices.cs
+++ b/server.core/Ingest/AdobePdfServices.cs
@@ -195,7 +195,9 @@ public sealed class AdobePdfServices : IAdobePdfServices
             Directory.CreateDirectory(dir);
         }
 
+        await using var input = streamAsset.Stream;
         await using var output = File.Open(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        await streamAsset.Stream.CopyToAsync(output, cancellationToken);
+        await input.CopyToAsync(output, cancellationToken);
     }
 }
+

--- a/server.core/Ingest/PdfProcessor.cs
+++ b/server.core/Ingest/PdfProcessor.cs
@@ -27,6 +27,36 @@ public sealed record PdfChunk(int Index, int FromPage, int ToPage, string Path)
     public int PageCount => ToPage - FromPage + 1;
 }
 
+internal static class PdfPathSafeName
+{
+    private const string InvalidFileIdToken = "invalid-file-id";
+
+    public static string FromFileId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return InvalidFileIdToken;
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            sb.Append(Array.IndexOf(invalid, ch) >= 0 ? '_' : ch);
+        }
+
+        var sanitized = sb.ToString().Trim();
+        if (string.IsNullOrWhiteSpace(sanitized)
+            || string.Equals(sanitized, ".", StringComparison.Ordinal)
+            || string.Equals(sanitized, "..", StringComparison.Ordinal))
+        {
+            return InvalidFileIdToken;
+        }
+
+        return sanitized;
+    }
+}
+
 public sealed class PdfProcessor : IPdfProcessor
 {
     private readonly IAdobePdfServices _adobePdfServices;
@@ -72,7 +102,7 @@ public sealed class PdfProcessor : IPdfProcessor
     public async Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
     {
         var totalSw = Stopwatch.StartNew();
-        var safeFileId = SanitizeForFileName(fileId);
+        var safeFileId = PdfPathSafeName.FromFileId(fileId);
         var runId = Guid.NewGuid().ToString("N");
         var workDir = GetWorkDir(safeFileId, runId, _options.WorkDirRoot);
         Directory.CreateDirectory(workDir);
@@ -582,25 +612,6 @@ public sealed class PdfProcessor : IPdfProcessor
         return Path.Combine(baseTmp, "readable-ingest", safeFileId, runId);
     }
 
-    /// <summary>
-    /// Produces a filesystem-safe identifier for use in temporary file names.
-    /// </summary>
-    private static string SanitizeForFileName(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return "file";
-        }
-
-        var invalid = Path.GetInvalidFileNameChars();
-        var sb = new StringBuilder(value.Length);
-        foreach (var ch in value)
-        {
-            sb.Append(Array.IndexOf(invalid, ch) >= 0 ? '_' : ch);
-        }
-
-        return sb.ToString().Trim();
-    }
 
     /// <summary>
     /// Merges PDFs into a single document, preserving the provided input order.
@@ -626,7 +637,7 @@ public sealed class NoopPdfProcessor : IPdfProcessor
 {
     public async Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
     {
-        var safeFileId = Sanitize(fileId);
+        var safeFileId = PdfPathSafeName.FromFileId(fileId);
         var tmpRoot = Directory.Exists("/tmp") ? "/tmp" : Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
         var workDir = Path.Combine(tmpRoot, "readable-ingest", safeFileId, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(workDir);
@@ -664,21 +675,6 @@ public sealed class NoopPdfProcessor : IPdfProcessor
         return new PdfProcessResult(outputPath);
     }
 
-    private static string Sanitize(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return "file";
-        }
-
-        var invalid = Path.GetInvalidFileNameChars();
-        var sb = new StringBuilder(value.Length);
-        foreach (var ch in value)
-        {
-            sb.Append(Array.IndexOf(invalid, ch) >= 0 ? '_' : ch);
-        }
-
-        return sb.ToString().Trim();
-    }
 }
+
 

--- a/server.core/Ingest/PdfProcessor.cs
+++ b/server.core/Ingest/PdfProcessor.cs
@@ -66,14 +66,15 @@ public sealed class PdfProcessor : IPdfProcessor
     /// Runs the PDF ingest pipeline: chunking, autotagging, merging, and remediation.
     /// </summary>
     /// <remarks>
-    /// This method writes intermediate artifacts to a per-file working directory under <c>/tmp</c> (or a configured
+    /// This method writes intermediate artifacts to a per-attempt working directory under <c>/tmp</c> (or a configured
     /// root), and expects <see cref="IAdobePdfServices" /> to produce tagged PDFs for each chunk.
     /// </remarks>
     public async Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
     {
         var totalSw = Stopwatch.StartNew();
         var safeFileId = SanitizeForFileName(fileId);
-        var workDir = GetWorkDir(safeFileId, _options.WorkDirRoot);
+        var runId = Guid.NewGuid().ToString("N");
+        var workDir = GetWorkDir(safeFileId, runId, _options.WorkDirRoot);
         Directory.CreateDirectory(workDir);
 
         // persist the incoming stream locally so we can reliably split it.
@@ -570,7 +571,7 @@ public sealed class PdfProcessor : IPdfProcessor
     /// Prefers <c>/tmp</c> when available to avoid filling application directories, and falls back to the platform
     /// temp directory when needed.
     /// </remarks>
-    private static string GetWorkDir(string safeFileId, string? workDirRoot)
+    private static string GetWorkDir(string safeFileId, string runId, string? workDirRoot)
     {
         // Prefer `/tmp`; fall back to platform temp if unavailable.
         var baseTmp =
@@ -578,7 +579,7 @@ public sealed class PdfProcessor : IPdfProcessor
                 ? (Directory.Exists("/tmp") ? "/tmp" : Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar))
                 : workDirRoot.TrimEnd(Path.DirectorySeparatorChar);
 
-        return Path.Combine(baseTmp, "readable-ingest", safeFileId);
+        return Path.Combine(baseTmp, "readable-ingest", safeFileId, runId);
     }
 
     /// <summary>
@@ -627,7 +628,7 @@ public sealed class NoopPdfProcessor : IPdfProcessor
     {
         var safeFileId = Sanitize(fileId);
         var tmpRoot = Directory.Exists("/tmp") ? "/tmp" : Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
-        var workDir = Path.Combine(tmpRoot, "readable-ingest", safeFileId);
+        var workDir = Path.Combine(tmpRoot, "readable-ingest", safeFileId, Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(workDir);
 
         var outputPath = Path.Combine(workDir, $"{safeFileId}.noop.pdf");
@@ -680,3 +681,4 @@ public sealed class NoopPdfProcessor : IPdfProcessor
         return sb.ToString().Trim();
     }
 }
+

--- a/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
+++ b/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
@@ -39,7 +39,7 @@ public sealed class PdfProcessorIntegrationTests
             await sut.ProcessAsync(fileId, inputStream, CancellationToken.None);
 
             var safeFileId = fileId;
-            var workDir = Path.Combine(runRoot, "readable-ingest", safeFileId);
+            var workDir = FindSingleAttemptWorkDir(runRoot, safeFileId);
 
             File.Exists(Path.Combine(workDir, $"{safeFileId}.source.pdf")).Should().BeTrue();
             File.Exists(Path.Combine(workDir, $"{safeFileId}.part001.pdf")).Should().BeTrue();
@@ -101,7 +101,7 @@ public sealed class PdfProcessorIntegrationTests
             using var output = new PdfDocument(new PdfReader(result.OutputPdfPath));
             output.IsTagged().Should().BeTrue();
 
-            var workDir = Path.Combine(runRoot, "readable-ingest", fileId);
+            var workDir = FindSingleAttemptWorkDir(runRoot, fileId);
             Directory.GetFiles(workDir, "*.part*.pdf").Should().BeEmpty();
             Directory.GetFiles(workDir, "*.part*.tagged.pdf").Should().BeEmpty();
             Directory.GetFiles(workDir, "*.remediated.pdf").Should().BeEmpty();
@@ -147,7 +147,7 @@ public sealed class PdfProcessorIntegrationTests
             adobe.Calls[0].InputPdfPath.Should().EndWith(".source.pdf");
             adobe.Calls[0].OutputTaggedPdfPath.Should().EndWith(".tagged.pdf");
 
-            var workDir = Path.Combine(runRoot, "readable-ingest", fileId);
+            var workDir = FindSingleAttemptWorkDir(runRoot, fileId);
             File.Exists(Path.Combine(workDir, $"{fileId}.tagged.pdf")).Should().BeTrue();
             Directory.GetFiles(workDir, "*.part*.pdf").Should().BeEmpty();
             Directory.GetFiles(workDir, "*.part*.tagged.pdf").Should().BeEmpty();
@@ -199,7 +199,7 @@ public sealed class PdfProcessorIntegrationTests
             using var output = new PdfDocument(new PdfReader(result.OutputPdfPath));
             output.IsTagged().Should().BeTrue();
 
-            var workDir = Path.Combine(runRoot, "readable-ingest", fileId);
+            var workDir = FindSingleAttemptWorkDir(runRoot, fileId);
             Directory.GetFiles(workDir, "*.part*.pdf").Should().BeEmpty();
             File.Exists(Path.Combine(workDir, $"{fileId}.tagged.pdf")).Should().BeFalse();
         }
@@ -341,6 +341,55 @@ public sealed class PdfProcessorIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task ProcessAsync_WhenRunTwiceForSameFileId_UsesDistinctAttemptDirectories()
+    {
+        var fileId = $"pdf-retry-test-{Guid.NewGuid():N}";
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", fileId);
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTestPdf(inputPdfPath, pageCount: 2);
+
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+            var adobe = new NoopAdobePdfServices(loggerFactory.CreateLogger<NoopAdobePdfServices>());
+            var remediation = new NoopPdfRemediationProcessor();
+            var options = Options.Create(new PdfProcessorOptions
+            {
+                UseAdobePdfServices = false,
+                UsePdfRemediationProcessor = false,
+                MaxPagesPerChunk = 200,
+                WorkDirRoot = runRoot
+            });
+
+            var sut = new PdfProcessor(adobe, remediation, options, loggerFactory.CreateLogger<PdfProcessor>());
+
+            await using var firstInputStream = File.OpenRead(inputPdfPath);
+            var firstResult = await sut.ProcessAsync(fileId, firstInputStream, CancellationToken.None);
+
+            await using var secondInputStream = File.OpenRead(inputPdfPath);
+            var secondResult = await sut.ProcessAsync(fileId, secondInputStream, CancellationToken.None);
+
+            var attemptRoot = FindAttemptRoot(runRoot, fileId);
+            var workDirs = Directory.GetDirectories(attemptRoot);
+
+            workDirs.Should().HaveCount(2);
+            firstResult.OutputPdfPath.Should().NotBe(secondResult.OutputPdfPath);
+            Path.GetDirectoryName(firstResult.OutputPdfPath).Should().NotBe(Path.GetDirectoryName(secondResult.OutputPdfPath));
+            workDirs.Should().Contain(Path.GetDirectoryName(firstResult.OutputPdfPath)!);
+            workDirs.Should().Contain(Path.GetDirectoryName(secondResult.OutputPdfPath)!);
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
     private sealed record AdobeCall(string InputPdfPath, string OutputTaggedPdfPath, string OutputTaggingReportPath);
 
     private sealed class CapturingAdobePdfServices : IAdobePdfServices
@@ -407,6 +456,21 @@ public sealed class PdfProcessorIntegrationTests
             Calls++;
             return Task.FromResult(new PdfRemediationResult(outputPdfPath));
         }
+    }
+
+    private static string FindAttemptRoot(string runRoot, string safeFileId)
+    {
+        var attemptRoot = Path.Combine(runRoot, "readable-ingest", safeFileId);
+        Directory.Exists(attemptRoot).Should().BeTrue($"attempt root should exist at {attemptRoot}");
+        return attemptRoot;
+    }
+
+    private static string FindSingleAttemptWorkDir(string runRoot, string safeFileId)
+    {
+        var attemptRoot = FindAttemptRoot(runRoot, safeFileId);
+        var workDirs = Directory.GetDirectories(attemptRoot);
+        workDirs.Should().ContainSingle($"expected exactly one attempt directory under {attemptRoot}");
+        return workDirs[0];
     }
 
     private static string FindRepoRoot()
@@ -479,3 +543,4 @@ public sealed class PdfProcessorIntegrationTests
         return pdf.GetNumberOfPages();
     }
 }
+

--- a/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
+++ b/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
@@ -342,6 +342,79 @@ public sealed class PdfProcessorIntegrationTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WithDotDotFileId_NormalizesAttemptRoot()
+    {
+        const string fileId = "..";
+        const string normalizedFileId = "invalid-file-id";
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"pdf-dotdot-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTestPdf(inputPdfPath, pageCount: 1);
+
+            await using var inputStream = File.OpenRead(inputPdfPath);
+
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+            var adobe = new NoopAdobePdfServices(loggerFactory.CreateLogger<NoopAdobePdfServices>());
+            var remediation = new NoopPdfRemediationProcessor();
+            var options = Options.Create(new PdfProcessorOptions
+            {
+                UseAdobePdfServices = false,
+                UsePdfRemediationProcessor = false,
+                MaxPagesPerChunk = 200,
+                WorkDirRoot = runRoot
+            });
+
+            var sut = new PdfProcessor(adobe, remediation, options, loggerFactory.CreateLogger<PdfProcessor>());
+
+            var result = await sut.ProcessAsync(fileId, inputStream, CancellationToken.None);
+            var attemptRoot = Path.Combine(runRoot, "readable-ingest", normalizedFileId);
+            var fullOutputPath = Path.GetFullPath(result.OutputPdfPath);
+            var fullAttemptRoot = Path.GetFullPath(attemptRoot + Path.DirectorySeparatorChar);
+
+            Directory.Exists(attemptRoot).Should().BeTrue();
+            fullOutputPath.Should().StartWith(fullAttemptRoot);
+            Path.GetFileName(result.OutputPdfPath).Should().Be($"{normalizedFileId}.source.pdf");
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task NoopProcessAsync_WithDotDotFileId_NormalizesAttemptRoot()
+    {
+        const string normalizedFileId = "invalid-file-id";
+        string? attemptRoot = null;
+
+        try
+        {
+            await using var inputStream = new MemoryStream("%PDF-1.7"u8.ToArray());
+            var sut = new NoopPdfProcessor();
+
+            var result = await sut.ProcessAsync("..", inputStream, CancellationToken.None);
+            var workDir = Path.GetDirectoryName(result.OutputPdfPath)!;
+            attemptRoot = Directory.GetParent(workDir)!.FullName;
+
+            Path.GetFileName(result.OutputPdfPath).Should().Be($"{normalizedFileId}.noop.pdf");
+            Directory.GetParent(workDir)!.Name.Should().Be(normalizedFileId);
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(attemptRoot) && Directory.Exists(attemptRoot))
+            {
+                Directory.Delete(attemptRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ProcessAsync_WhenRunTwiceForSameFileId_UsesDistinctAttemptDirectories()
     {
         var fileId = $"pdf-retry-test-{Guid.NewGuid():N}";
@@ -543,4 +616,6 @@ public sealed class PdfProcessorIntegrationTests
         return pdf.GetNumberOfPages();
     }
 }
+
+
 

--- a/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
+++ b/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
@@ -391,7 +391,7 @@ public sealed class PdfProcessorIntegrationTests
     public async Task NoopProcessAsync_WithDotDotFileId_NormalizesAttemptRoot()
     {
         const string normalizedFileId = "invalid-file-id";
-        string? attemptRoot = null;
+        string? workDir = null;
 
         try
         {
@@ -399,17 +399,16 @@ public sealed class PdfProcessorIntegrationTests
             var sut = new NoopPdfProcessor();
 
             var result = await sut.ProcessAsync("..", inputStream, CancellationToken.None);
-            var workDir = Path.GetDirectoryName(result.OutputPdfPath)!;
-            attemptRoot = Directory.GetParent(workDir)!.FullName;
+            workDir = Path.GetDirectoryName(result.OutputPdfPath)!;
 
             Path.GetFileName(result.OutputPdfPath).Should().Be($"{normalizedFileId}.noop.pdf");
             Directory.GetParent(workDir)!.Name.Should().Be(normalizedFileId);
         }
         finally
         {
-            if (!string.IsNullOrWhiteSpace(attemptRoot) && Directory.Exists(attemptRoot))
+            if (!string.IsNullOrWhiteSpace(workDir) && Directory.Exists(workDir))
             {
-                Directory.Delete(attemptRoot, recursive: true);
+                Directory.Delete(workDir, recursive: true);
             }
         }
     }
@@ -616,6 +615,7 @@ public sealed class PdfProcessorIntegrationTests
         return pdf.GetNumberOfPages();
     }
 }
+
 
 
 


### PR DESCRIPTION
Incorporates a unique run ID into the working directory path to prevent file collisions when a PDF is re-processed or retried for the same file ID.

Untested locally 🤷 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup by explicitly disposing input streams during PDF ingestion.

* **Refactor**
  * Intermediate artifacts are now isolated in per-attempt work directories and use filesystem-safe file IDs; no public APIs changed.
  * No-op processing updated to follow per-attempt directory semantics.

* **Tests**
  * Added integration tests for unsafe file-ID normalization and for distinct per-attempt directories across repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->