### PR TITLE
Harden no-header table remediation

### DIFF
--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -83,6 +83,13 @@ public static class IngestServiceCollectionExtensions
                     configuration.GetValue<bool?>("Ingest:DemoteLikelyFormLayoutTables")
                     ?? configuration.GetValue<bool?>("INGEST_DEMOTE_LIKELY_FORM_LAYOUT_TABLES")
                     ?? true;
+
+                o.DemoteNoHeaderTables =
+                    configuration.GetValue<bool?>("Ingest:DemoteNoHeaderTables")
+                    ?? configuration.GetValue<bool?>("INGEST_DEMOTE_NO_HEADER_TABLES")
+                    ?? configuration.GetValue<bool?>("Ingest:DemoteLikelyFormLayoutTables")
+                    ?? configuration.GetValue<bool?>("INGEST_DEMOTE_LIKELY_FORM_LAYOUT_TABLES")
+                    ?? true;
             });
 
             services.AddSingleton<OpenAiRemediationConfig>(sp =>

--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using server.core.Remediate;
 using server.core.Remediate.AltText;
 using server.core.Remediate.Bookmarks;
 using server.core.Remediate.Rasterize;
+using server.core.Remediate.Table;
 using server.core.Remediate.Title;
 
 namespace server.core.Ingest;
@@ -16,7 +17,8 @@ public static class IngestServiceCollectionExtensions
     /// </summary>
     /// <remarks>
     /// When PDF remediation is enabled, OpenAI-backed services are required for title and alt text generation.
-    /// Model selection can be overridden via <c>OPENAI_ALT_TEXT_MODEL</c> and <c>OPENAI_PDF_TITLE_MODEL</c>.
+    /// Model selection can be overridden via <c>OPENAI_ALT_TEXT_MODEL</c>, <c>OPENAI_PDF_TITLE_MODEL</c>, and
+    /// <c>OPENAI_PDF_TABLE_CLASSIFICATION_MODEL</c>.
     /// When Adobe PDF Services is enabled, credentials must be provided via environment variables
     /// or configuration settings.
     /// </remarks>
@@ -71,6 +73,16 @@ public static class IngestServiceCollectionExtensions
                     configuration.GetValue<bool?>("Ingest:DemoteSmallTablesWithoutHeaders")
                     ?? configuration.GetValue<bool?>("INGEST_DEMOTE_SMALL_TABLES_WITHOUT_HEADERS")
                     ?? true;
+
+                o.PromoteFirstRowHeadersForNoHeaderTables =
+                    configuration.GetValue<bool?>("Ingest:PromoteFirstRowHeadersForNoHeaderTables")
+                    ?? configuration.GetValue<bool?>("INGEST_PROMOTE_FIRST_ROW_HEADERS_FOR_NO_HEADER_TABLES")
+                    ?? true;
+
+                o.DemoteLikelyFormLayoutTables =
+                    configuration.GetValue<bool?>("Ingest:DemoteLikelyFormLayoutTables")
+                    ?? configuration.GetValue<bool?>("INGEST_DEMOTE_LIKELY_FORM_LAYOUT_TABLES")
+                    ?? true;
             });
 
             services.AddSingleton<OpenAiRemediationConfig>(sp =>
@@ -95,7 +107,17 @@ public static class IngestServiceCollectionExtensions
                     ?? configuration["OpenAI__PdfTitleModel"]
                     ?? "gpt-5-mini";
 
-                return new OpenAiRemediationConfig(apiKey, altTextModel, pdfTitleModel);
+                var pdfTableClassificationModel =
+                    configuration["OPENAI_PDF_TABLE_CLASSIFICATION_MODEL"]
+                    ?? configuration["OpenAI:PdfTableClassificationModel"]
+                    ?? configuration["OpenAI__PdfTableClassificationModel"]
+                    ?? "gpt-5-mini";
+
+                return new OpenAiRemediationConfig(
+                    apiKey,
+                    altTextModel,
+                    pdfTitleModel,
+                    pdfTableClassificationModel);
             });
             services.AddSingleton<IAltTextService>(sp =>
             {
@@ -106,6 +128,11 @@ public static class IngestServiceCollectionExtensions
             {
                 var cfg = sp.GetRequiredService<OpenAiRemediationConfig>();
                 return new OpenAIPdfTitleService(cfg.ApiKey, cfg.PdfTitleModel);
+            });
+            services.AddSingleton<IPdfTableClassificationService>(sp =>
+            {
+                var cfg = sp.GetRequiredService<OpenAiRemediationConfig>();
+                return new OpenAIPdfTableClassificationService(cfg.ApiKey, cfg.PdfTableClassificationModel);
             });
             if (options.UsePdfBookmarks)
             {
@@ -150,5 +177,9 @@ public static class IngestServiceCollectionExtensions
             ?? configuration["OpenAI__ApiKey"];
     }
 
-    private sealed record OpenAiRemediationConfig(string ApiKey, string AltTextModel, string PdfTitleModel);
+    private sealed record OpenAiRemediationConfig(
+        string ApiKey,
+        string AltTextModel,
+        string PdfTitleModel,
+        string PdfTableClassificationModel);
 }

--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -90,6 +90,11 @@ public static class IngestServiceCollectionExtensions
                     ?? configuration.GetValue<bool?>("Ingest:DemoteLikelyFormLayoutTables")
                     ?? configuration.GetValue<bool?>("INGEST_DEMOTE_LIKELY_FORM_LAYOUT_TABLES")
                     ?? true;
+
+                o.NoHeaderTableClassificationTimeoutSeconds =
+                    configuration.GetValue<int?>("Ingest:NoHeaderTableClassificationTimeoutSeconds")
+                    ?? configuration.GetValue<int?>("INGEST_NO_HEADER_TABLE_CLASSIFICATION_TIMEOUT_SECONDS")
+                    ?? 30;
             });
 
             services.AddSingleton<OpenAiRemediationConfig>(sp =>

--- a/server.core/Remediate/PdfRemediationOptions.cs
+++ b/server.core/Remediate/PdfRemediationOptions.cs
@@ -22,12 +22,21 @@ public sealed class PdfRemediationOptions
     public bool DemoteSmallTablesWithoutHeaders { get; set; } = true;
 
     /// <summary>
-    /// When enabled, promotes first-row <c>/TD</c> cells to <c>/TH</c> for no-header tables that look like data tables.
+    /// When enabled, demotes multi-row, multi-column no-header tables to <c>/Div</c>.
+    /// </summary>
+    /// <remarks>
+    /// This avoids producing tagged tables that fail accessibility checks with "Tables should have headers" when
+    /// the source PDF does not already contain usable table header cells.
+    /// </remarks>
+    public bool DemoteNoHeaderTables { get; set; } = true;
+
+    /// <summary>
+    /// Legacy option retained for existing configuration binding. First-row header promotion is no longer used.
     /// </summary>
     public bool PromoteFirstRowHeadersForNoHeaderTables { get; set; } = true;
 
     /// <summary>
-    /// When enabled, demotes multi-row, multi-column no-header tables that look like form/layout tables to <c>/Div</c>.
+    /// Legacy option retained for existing configuration binding. Use <see cref="DemoteNoHeaderTables" /> instead.
     /// </summary>
     public bool DemoteLikelyFormLayoutTables { get; set; } = true;
 }

--- a/server.core/Remediate/PdfRemediationOptions.cs
+++ b/server.core/Remediate/PdfRemediationOptions.cs
@@ -31,6 +31,11 @@ public sealed class PdfRemediationOptions
     public bool DemoteNoHeaderTables { get; set; } = true;
 
     /// <summary>
+    /// Maximum time to wait for each no-header table classification request before leaving that table unchanged.
+    /// </summary>
+    public int NoHeaderTableClassificationTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
     /// Legacy option retained for existing configuration binding. First-row header promotion is no longer used.
     /// </summary>
     public bool PromoteFirstRowHeadersForNoHeaderTables { get; set; } = true;

--- a/server.core/Remediate/PdfRemediationOptions.cs
+++ b/server.core/Remediate/PdfRemediationOptions.cs
@@ -20,4 +20,14 @@ public sealed class PdfRemediationOptions
     /// Disable this if you find it demoting true data tables.
     /// </remarks>
     public bool DemoteSmallTablesWithoutHeaders { get; set; } = true;
+
+    /// <summary>
+    /// When enabled, promotes first-row <c>/TD</c> cells to <c>/TH</c> for no-header tables that look like data tables.
+    /// </summary>
+    public bool PromoteFirstRowHeadersForNoHeaderTables { get; set; } = true;
+
+    /// <summary>
+    /// When enabled, demotes multi-row, multi-column no-header tables that look like form/layout tables to <c>/Div</c>.
+    /// </summary>
+    public bool DemoteLikelyFormLayoutTables { get; set; } = true;
 }

--- a/server.core/Remediate/PdfRemediationOptions.cs
+++ b/server.core/Remediate/PdfRemediationOptions.cs
@@ -36,7 +36,7 @@ public sealed class PdfRemediationOptions
     public int NoHeaderTableClassificationTimeoutSeconds { get; set; } = 30;
 
     /// <summary>
-    /// Legacy option retained for existing configuration binding. First-row header promotion is no longer used.
+    /// When enabled, promotes the first usable row of confident no-header data tables into <c>/TH</c> cells.
     /// </summary>
     public bool PromoteFirstRowHeadersForNoHeaderTables { get; set; } = true;
 

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -277,13 +277,11 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
             foreach (var tableRemediation in noHeaderTableRemediations)
             {
                 _logger.LogInformation(
-                    "No-header table remediation decision in {fileId}: action={action} rows={rows} columns={columns} firstRow={firstRow} reason={reason}",
+                    "No-header table remediation decision in {fileId}: action={action} rows={rows} columns={columns}",
                     fileId,
                     tableRemediation.Action,
                     tableRemediation.RowCount,
-                    tableRemediation.MaxColumnCount,
-                    tableRemediation.FirstRowSnippet,
-                    tableRemediation.Reason);
+                    tableRemediation.MaxColumnCount);
             }
 
             using (LogStage.Begin(_logger, fileId, "ensure_table_summaries", null, kind: "Remediation stage"))

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -259,9 +259,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                        "remediate_no_header_tables",
                        new
                        {
-                           promoteFirstRowHeadersForNoHeaderTables =
-                               _options.PromoteFirstRowHeadersForNoHeaderTables,
-                           demoteLikelyFormLayoutTables = _options.DemoteLikelyFormLayoutTables,
+                           demoteNoHeaderTables = _options.DemoteNoHeaderTables,
                        },
                        kind: "Remediation stage"))
             {
@@ -269,8 +267,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     pdf,
                     _tableClassificationService,
                     primaryLanguage,
-                    promoteFirstRowHeadersForNoHeaderTables: _options.PromoteFirstRowHeadersForNoHeaderTables,
-                    demoteLikelyFormLayoutTables: _options.DemoteLikelyFormLayoutTables,
+                    demoteNoHeaderTables: _options.DemoteNoHeaderTables,
                     cancellationToken);
             }
             foreach (var tableRemediation in noHeaderTableRemediations)

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -260,6 +260,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                        new
                        {
                            demoteNoHeaderTables = _options.DemoteNoHeaderTables,
+                           promoteFirstRowHeadersForNoHeaderTables = _options.PromoteFirstRowHeadersForNoHeaderTables,
                            noHeaderTableClassificationTimeoutSeconds = _options.NoHeaderTableClassificationTimeoutSeconds,
                        },
                        kind: "Remediation stage"))
@@ -269,6 +270,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     _tableClassificationService,
                     primaryLanguage,
                     demoteNoHeaderTables: _options.DemoteNoHeaderTables,
+                    promoteFirstRowHeadersForNoHeaderTables: _options.PromoteFirstRowHeadersForNoHeaderTables,
                     classificationTimeout: TimeSpan.FromSeconds(Math.Max(1, _options.NoHeaderTableClassificationTimeoutSeconds)),
                     cancellationToken);
             }

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -260,6 +260,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                        new
                        {
                            demoteNoHeaderTables = _options.DemoteNoHeaderTables,
+                           noHeaderTableClassificationTimeoutSeconds = _options.NoHeaderTableClassificationTimeoutSeconds,
                        },
                        kind: "Remediation stage"))
             {
@@ -268,6 +269,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     _tableClassificationService,
                     primaryLanguage,
                     demoteNoHeaderTables: _options.DemoteNoHeaderTables,
+                    classificationTimeout: TimeSpan.FromSeconds(Math.Max(1, _options.NoHeaderTableClassificationTimeoutSeconds)),
                     cancellationToken);
             }
             foreach (var tableRemediation in noHeaderTableRemediations)

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -16,6 +16,7 @@ using IOPath = System.IO.Path;
 using server.core.Remediate.AltText;
 using server.core.Remediate.Bookmarks;
 using server.core.Remediate.Rasterize;
+using server.core.Remediate.Table;
 using server.core.Remediate.Title;
 using server.core.Telemetry;
 
@@ -69,6 +70,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
     private readonly IAltTextService _altTextService;
     private readonly IPdfBookmarkService _bookmarkService;
     private readonly IPdfPageRasterizer _pageRasterizer;
+    private readonly IPdfTableClassificationService _tableClassificationService;
     private readonly IPdfTitleService _pdfTitleService;
     private readonly PdfRemediationOptions _options;
     private readonly ILogger<PdfRemediationProcessor> _logger;
@@ -80,10 +82,30 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
         IPdfTitleService pdfTitleService,
         IOptions<PdfRemediationOptions> options,
         ILogger<PdfRemediationProcessor> logger)
+        : this(
+            altTextService,
+            bookmarkService,
+            pageRasterizer,
+            new SamplePdfTableClassificationService(),
+            pdfTitleService,
+            options,
+            logger)
+    {
+    }
+
+    public PdfRemediationProcessor(
+        IAltTextService altTextService,
+        IPdfBookmarkService bookmarkService,
+        IPdfPageRasterizer pageRasterizer,
+        IPdfTableClassificationService tableClassificationService,
+        IPdfTitleService pdfTitleService,
+        IOptions<PdfRemediationOptions> options,
+        ILogger<PdfRemediationProcessor> logger)
     {
         _altTextService = altTextService ?? throw new ArgumentNullException(nameof(altTextService));
         _bookmarkService = bookmarkService ?? throw new ArgumentNullException(nameof(bookmarkService));
         _pageRasterizer = pageRasterizer ?? throw new ArgumentNullException(nameof(pageRasterizer));
+        _tableClassificationService = tableClassificationService ?? throw new ArgumentNullException(nameof(tableClassificationService));
         _pdfTitleService = pdfTitleService ?? throw new ArgumentNullException(nameof(pdfTitleService));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -99,6 +121,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
             altTextService,
             bookmarkService,
             pageRasterizer,
+            new SamplePdfTableClassificationService(),
             pdfTitleService,
             Options.Create(new PdfRemediationOptions()),
             logger)
@@ -227,6 +250,39 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     "Demoted {count} likely layout table(s) in {fileId}.",
                     layoutTablesDemoted,
                     fileId);
+            }
+
+            IReadOnlyList<PdfNoHeaderTableRemediation> noHeaderTableRemediations;
+            using (LogStage.Begin(
+                       _logger,
+                       fileId,
+                       "remediate_no_header_tables",
+                       new
+                       {
+                           promoteFirstRowHeadersForNoHeaderTables =
+                               _options.PromoteFirstRowHeadersForNoHeaderTables,
+                           demoteLikelyFormLayoutTables = _options.DemoteLikelyFormLayoutTables,
+                       },
+                       kind: "Remediation stage"))
+            {
+                noHeaderTableRemediations = await PdfTableRoleRemediator.RemediateNoHeaderTablesAsync(
+                    pdf,
+                    _tableClassificationService,
+                    primaryLanguage,
+                    promoteFirstRowHeadersForNoHeaderTables: _options.PromoteFirstRowHeadersForNoHeaderTables,
+                    demoteLikelyFormLayoutTables: _options.DemoteLikelyFormLayoutTables,
+                    cancellationToken);
+            }
+            foreach (var tableRemediation in noHeaderTableRemediations)
+            {
+                _logger.LogInformation(
+                    "No-header table remediation decision in {fileId}: action={action} rows={rows} columns={columns} firstRow={firstRow} reason={reason}",
+                    fileId,
+                    tableRemediation.Action,
+                    tableRemediation.RowCount,
+                    tableRemediation.MaxColumnCount,
+                    tableRemediation.FirstRowSnippet,
+                    tableRemediation.Reason);
             }
 
             using (LogStage.Begin(_logger, fileId, "ensure_table_summaries", null, kind: "Remediation stage"))

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -25,6 +25,9 @@ internal sealed record PdfNoHeaderTableRemediation(
 internal static class PdfTableRoleRemediator
 {
     private const int MaxCellTextChars = 120;
+    private const int MaxMarkedContentTraversalDepth = 64;
+    private const int MaxMarkedContentTraversalNodes = 4096;
+    private const int MaxTableDemotionTraversalNodes = 4096;
     private const double MinClassifierConfidence = 0.7;
     private static readonly PdfName RoleTable = new("Table");
     private static readonly PdfName RoleTHead = new("THead");
@@ -664,7 +667,7 @@ internal static class PdfTableRoleRemediator
             return alt;
         }
 
-        var refs = ListMarkedContentRefs(cell, pageObjNumToPageNumber);
+        var refs = ListMarkedContentRefs(cell, pageObjNumToPageNumber, cancellationToken);
         if (refs.Count == 0)
         {
             return null;
@@ -693,7 +696,8 @@ internal static class PdfTableRoleRemediator
 
     private static List<(int pageNumber, int mcid)> ListMarkedContentRefs(
         PdfDictionary structElem,
-        Dictionary<int, int> pageObjNumToPageNumber)
+        Dictionary<int, int> pageObjNumToPageNumber,
+        CancellationToken cancellationToken)
     {
         var defaultPageDict = structElem.GetAsDictionary(PdfName.Pg);
         var kids = structElem.Get(PdfName.K);
@@ -703,35 +707,60 @@ internal static class PdfTableRoleRemediator
         }
 
         var results = new List<(int pageNumber, int mcid)>();
-        CollectMarkedContentRefsRecursive(kids, defaultPageDict, pageObjNumToPageNumber, results);
+        var state = new MarkedContentTraversalState();
+        CollectMarkedContentRefsRecursive(
+            kids,
+            defaultPageDict,
+            pageObjNumToPageNumber,
+            results,
+            state,
+            depth: 0,
+            cancellationToken);
         return results;
     }
 
     private static void CollectMarkedContentRefsRecursive(
-        PdfObject node,
+        PdfObject? node,
         PdfDictionary? inheritedPageDict,
         Dictionary<int, int> pageObjNumToPageNumber,
-        List<(int pageNumber, int mcid)> results)
+        List<(int pageNumber, int mcid)> results,
+        MarkedContentTraversalState state,
+        int depth,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (node is null
+            || depth > MaxMarkedContentTraversalDepth
+            || !state.TryEnter(node, MaxMarkedContentTraversalNodes))
+        {
+            return;
+        }
+
         var dereferenced = Dereference(node);
         if (dereferenced is null)
         {
             return;
         }
 
-        node = dereferenced;
-
-        if (node is PdfArray array)
+        if (dereferenced is PdfArray array)
         {
             foreach (var item in array)
             {
-                CollectMarkedContentRefsRecursive(item, inheritedPageDict, pageObjNumToPageNumber, results);
+                CollectMarkedContentRefsRecursive(
+                    item,
+                    inheritedPageDict,
+                    pageObjNumToPageNumber,
+                    results,
+                    state,
+                    depth + 1,
+                    cancellationToken);
             }
 
             return;
         }
 
-        if (node is PdfNumber num)
+        if (dereferenced is PdfNumber num)
         {
             var pageNumber = TryResolvePageNumber(inheritedPageDict, pageObjNumToPageNumber);
             if (pageNumber is not null)
@@ -742,7 +771,7 @@ internal static class PdfTableRoleRemediator
             return;
         }
 
-        if (node is not PdfDictionary dict)
+        if (dereferenced is not PdfDictionary dict)
         {
             return;
         }
@@ -753,7 +782,14 @@ internal static class PdfTableRoleRemediator
             var kids = dict.Get(PdfName.K);
             if (kids is not null)
             {
-                CollectMarkedContentRefsRecursive(kids, nestedPageDict, pageObjNumToPageNumber, results);
+                CollectMarkedContentRefsRecursive(
+                    kids,
+                    nestedPageDict,
+                    pageObjNumToPageNumber,
+                    results,
+                    state,
+                    depth + 1,
+                    cancellationToken);
             }
 
             return;
@@ -850,14 +886,26 @@ internal static class PdfTableRoleRemediator
         table.Put(PdfName.S, RoleDiv);
 
         var stack = new Stack<PdfObject?>();
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var nodesVisited = 0;
         stack.Push(table.Get(PdfName.K));
 
         while (stack.Count > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (++nodesVisited > MaxTableDemotionTraversalNodes)
+            {
+                return;
+            }
+
             var node = stack.Pop();
             if (node is null)
+            {
+                continue;
+            }
+
+            if (!TryMarkVisited(node, visited))
             {
                 continue;
             }
@@ -1068,6 +1116,18 @@ internal static class PdfTableRoleRemediator
 
     private static bool IsStructElemDictionary(PdfDictionary dict) => dict.ContainsKey(PdfName.S);
 
+    private static bool TryMarkVisited(PdfObject node, HashSet<(int objNum, int genNum)> visited)
+    {
+        if (node is PdfIndirectReference reference)
+        {
+            return visited.Add((reference.GetObjNumber(), reference.GetGenNumber()));
+        }
+
+        var objectReference = node.GetIndirectReference();
+        return objectReference is null
+            || visited.Add((objectReference.GetObjNumber(), objectReference.GetGenNumber()));
+    }
+
     private sealed record TableInventory(
         PdfDictionary Element,
         IReadOnlyList<TableRowInventory> Rows,
@@ -1092,6 +1152,23 @@ internal static class PdfTableRoleRemediator
     private sealed record TableRowInventory(PdfDictionary Element, IReadOnlyList<TableCellInventory> Cells);
 
     private sealed record TableCellInventory(PdfDictionary Element, PdfName Role, string Text);
+
+    private sealed class MarkedContentTraversalState
+    {
+        private readonly HashSet<(int objNum, int genNum)> _visited = new();
+
+        private int _nodesVisited;
+
+        public bool TryEnter(PdfObject node, int maxNodes)
+        {
+            if (++_nodesVisited > maxNodes)
+            {
+                return false;
+            }
+
+            return TryMarkVisited(node, _visited);
+        }
+    }
 
     private sealed class McidTextListener : IEventListener
     {

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -78,6 +78,7 @@ internal static class PdfTableRoleRemediator
         IPdfTableClassificationService tableClassificationService,
         string? primaryLanguage,
         bool demoteNoHeaderTables,
+        bool promoteFirstRowHeadersForNoHeaderTables,
         TimeSpan classificationTimeout,
         CancellationToken cancellationToken)
     {
@@ -164,6 +165,14 @@ internal static class PdfTableRoleRemediator
 
             if (isConfidentDataTable)
             {
+                if (!promoteFirstRowHeadersForNoHeaderTables)
+                {
+                    results.Add(CreateUnchangedResult(
+                        inventory,
+                        "classified as data table; first-row header promotion disabled"));
+                    continue;
+                }
+
                 var promoted = PromoteHeaderRowToTableHead(inventory, cancellationToken);
                 results.Add(
                     new PdfNoHeaderTableRemediation(

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -1,14 +1,43 @@
+using System.Text;
+using iText.Kernel.Geom;
 using iText.Kernel.Pdf;
+using iText.Kernel.Pdf.Canvas.Parser;
+using iText.Kernel.Pdf.Canvas.Parser.Data;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
+using server.core.Remediate.Table;
 
 namespace server.core.Remediate;
 
+internal enum PdfNoHeaderTableRemediationAction
+{
+    PromotedFirstRow,
+    DemotedLayoutTable,
+    LeftUnchanged,
+}
+
+internal sealed record PdfNoHeaderTableRemediation(
+    PdfNoHeaderTableRemediationAction Action,
+    int RowCount,
+    int MaxColumnCount,
+    string FirstRowSnippet,
+    string Reason);
+
 internal static class PdfTableRoleRemediator
 {
+    private const int MaxCellTextChars = 120;
+    private const double MinClassifierConfidence = 0.7;
     private static readonly PdfName RoleTable = new("Table");
+    private static readonly PdfName RoleTHead = new("THead");
+    private static readonly PdfName RoleTBody = new("TBody");
+    private static readonly PdfName RoleTFoot = new("TFoot");
     private static readonly PdfName RoleTr = new("TR");
     private static readonly PdfName RoleTh = new("TH");
     private static readonly PdfName RoleTd = new("TD");
     private static readonly PdfName RoleDiv = new("Div");
+    private static readonly PdfName AttrOwnerKey = new("O");
+    private static readonly PdfName AttrOwnerTable = new("Table");
+    private static readonly PdfName AttrScopeKey = new("Scope");
+    private static readonly PdfName AttrScopeColumn = new("Column");
 
     public static int DemoteLikelyLayoutTables(
         PdfDocument pdf,
@@ -45,67 +74,127 @@ internal static class PdfTableRoleRemediator
         return demoted;
     }
 
-    private static List<PdfDictionary> ListStructElementsByRole(
+    public static async Task<IReadOnlyList<PdfNoHeaderTableRemediation>> RemediateNoHeaderTablesAsync(
         PdfDocument pdf,
-        PdfName role,
+        IPdfTableClassificationService tableClassificationService,
+        string? primaryLanguage,
+        bool promoteFirstRowHeadersForNoHeaderTables,
+        bool demoteLikelyFormLayoutTables,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var catalogDict = pdf.GetCatalog().GetPdfObject();
-        var structTreeRootDict = catalogDict.GetAsDictionary(PdfName.StructTreeRoot);
-        if (structTreeRootDict is null)
+        if (!pdf.IsTagged())
         {
             return [];
         }
 
-        var rootKids = structTreeRootDict.Get(PdfName.K);
-        if (rootKids is null)
+        if (!promoteFirstRowHeadersForNoHeaderTables && !demoteLikelyFormLayoutTables)
         {
             return [];
         }
 
-        var results = new List<PdfDictionary>();
-        TraverseTagTreeForList(rootKids, role, results, cancellationToken);
+        var tables = ListStructElementsByRole(pdf, RoleTable, cancellationToken);
+        if (tables.Count == 0)
+        {
+            return [];
+        }
+
+        var pageObjNumToPageNumber = BuildPageObjectNumberToPageNumberMap(pdf);
+        var pageMcidTextCache = new Dictionary<int, Dictionary<int, string>>();
+        var results = new List<PdfNoHeaderTableRemediation>();
+
+        foreach (var table in tables)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var inventory = BuildTableInventory(
+                pdf,
+                table,
+                pageObjNumToPageNumber,
+                pageMcidTextCache,
+                cancellationToken);
+
+            if (inventory.HeaderCellCount > 0)
+            {
+                continue;
+            }
+
+            if (inventory.HasNestedTable)
+            {
+                results.Add(CreateUnchangedResult(inventory, "left unchanged; nested table structure"));
+                continue;
+            }
+
+            if (inventory.RowCount < 2 || inventory.MaxColumnCount < 2)
+            {
+                results.Add(CreateUnchangedResult(inventory, "left unchanged; fewer than 2 rows or 2 columns"));
+                continue;
+            }
+
+            var request = inventory.ToClassificationRequest(primaryLanguage);
+            var classification = await tableClassificationService.ClassifyAsync(request, cancellationToken);
+            var confidence = Math.Clamp(classification.Confidence, 0, 1);
+            if (confidence < MinClassifierConfidence)
+            {
+                results.Add(
+                    CreateUnchangedResult(
+                        inventory,
+                        $"left unchanged; table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}"));
+                continue;
+            }
+
+            if (classification.Kind == PdfTableKind.DataTable && promoteFirstRowHeadersForNoHeaderTables)
+            {
+                var promoted = PromoteFirstRowCellsToHeaders(inventory, cancellationToken);
+                results.Add(
+                    new PdfNoHeaderTableRemediation(
+                        promoted > 0
+                            ? PdfNoHeaderTableRemediationAction.PromotedFirstRow
+                            : PdfNoHeaderTableRemediationAction.LeftUnchanged,
+                        inventory.RowCount,
+                        inventory.MaxColumnCount,
+                        inventory.FirstRowSnippet,
+                        promoted > 0
+                            ? "classified as data table; promoted first row cells to TH"
+                            : "classified as data table but no first-row TD cells were available to promote"));
+                continue;
+            }
+
+            if (classification.Kind == PdfTableKind.LayoutOrFormTable && demoteLikelyFormLayoutTables)
+            {
+                DemoteTableAndDescendants(table, cancellationToken);
+                results.Add(
+                    new PdfNoHeaderTableRemediation(
+                        PdfNoHeaderTableRemediationAction.DemotedLayoutTable,
+                        inventory.RowCount,
+                        inventory.MaxColumnCount,
+                        inventory.FirstRowSnippet,
+                        "classified as layout/form table; demoted table roles"));
+                continue;
+            }
+
+            results.Add(
+                CreateUnchangedResult(
+                    inventory,
+                    classification.Kind switch
+                    {
+                        PdfTableKind.DataTable => "classified as data table but first-row header promotion is disabled",
+                        PdfTableKind.LayoutOrFormTable => "classified as layout/form table but form-layout demotion is disabled",
+                        _ => "left unchanged; table classifier returned uncertain",
+                    }));
+        }
+
         return results;
     }
 
-    private static void TraverseTagTreeForList(
-        PdfObject node,
-        PdfName role,
-        List<PdfDictionary> results,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        node = Dereference(node);
-
-        if (node is PdfArray array)
-        {
-            foreach (var item in array)
-            {
-                TraverseTagTreeForList(item, role, results, cancellationToken);
-            }
-
-            return;
-        }
-
-        if (node is not PdfDictionary dict)
-        {
-            return;
-        }
-
-        if (dict.ContainsKey(PdfName.S) && role.Equals(dict.GetAsName(PdfName.S)))
-        {
-            results.Add(dict);
-        }
-
-        var kids = dict.Get(PdfName.K);
-        if (kids is not null)
-        {
-            TraverseTagTreeForList(kids, role, results, cancellationToken);
-        }
-    }
+    private static PdfNoHeaderTableRemediation CreateUnchangedResult(TableInventory inventory, string reason) =>
+        new(
+            PdfNoHeaderTableRemediationAction.LeftUnchanged,
+            inventory.RowCount,
+            inventory.MaxColumnCount,
+            inventory.FirstRowSnippet,
+            reason);
 
     private static bool ShouldDemoteTable(
         PdfDictionary table,
@@ -144,7 +233,6 @@ internal static class PdfTableRoleRemediator
                 }
                 else if (RoleTh.Equals(role))
                 {
-                    // If a TH exists under a TR but wasn't found in the descendant scan for any reason, treat as data.
                     return false;
                 }
                 else if (RoleTable.Equals(role) || RoleTr.Equals(role))
@@ -156,7 +244,6 @@ internal static class PdfTableRoleRemediator
             maxCols = Math.Max(maxCols, cellCountInRow);
         }
 
-        // A /Table with no cells (even with /TR) is likely a tagging mistake.
         if (cellCountTotal == 0)
         {
             return true;
@@ -172,8 +259,418 @@ internal static class PdfTableRoleRemediator
             return true;
         }
 
-        // Keep multi-row, multi-column "real tables" (even without explicit /TH tags) as tables.
         return false;
+    }
+
+    private static TableInventory BuildTableInventory(
+        PdfDocument pdf,
+        PdfDictionary table,
+        Dictionary<int, int> pageObjNumToPageNumber,
+        Dictionary<int, Dictionary<int, string>> pageMcidTextCache,
+        CancellationToken cancellationToken)
+    {
+        var rowElements = new List<PdfDictionary>();
+        var hasNestedTable = CollectTableRows(table, rowElements, cancellationToken);
+        var rows = new List<TableRowInventory>();
+        var headerCellCount = 0;
+        var maxColumnCount = 0;
+
+        foreach (var row in rowElements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var cells = new List<TableCellInventory>();
+            foreach (var child in ListDirectStructElementChildren(row))
+            {
+                var role = child.GetAsName(PdfName.S);
+                if (!RoleTh.Equals(role) && !RoleTd.Equals(role))
+                {
+                    continue;
+                }
+
+                if (RoleTh.Equals(role))
+                {
+                    headerCellCount++;
+                }
+
+                var text = TryExtractCellText(
+                    pdf,
+                    child,
+                    pageObjNumToPageNumber,
+                    pageMcidTextCache,
+                    cancellationToken);
+
+                text = RemediationHelpers.NormalizeWhitespace(text ?? string.Empty);
+                if (text.Length > MaxCellTextChars)
+                {
+                    text = text[..MaxCellTextChars].Trim();
+                }
+
+                cells.Add(new TableCellInventory(child, role, text));
+            }
+
+            maxColumnCount = Math.Max(maxColumnCount, cells.Count);
+            rows.Add(new TableRowInventory(row, cells));
+        }
+
+        var firstRowSnippet = BuildFirstRowSnippet(rows);
+        return new TableInventory(table, rows, headerCellCount, maxColumnCount, hasNestedTable, firstRowSnippet);
+    }
+
+    private static int PromoteFirstRowCellsToHeaders(TableInventory inventory, CancellationToken cancellationToken)
+    {
+        if (inventory.Rows.Count == 0)
+        {
+            return 0;
+        }
+
+        var promoted = 0;
+        foreach (var cell in inventory.Rows[0].Cells)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!RoleTd.Equals(cell.Role))
+            {
+                continue;
+            }
+
+            cell.Element.Put(PdfName.S, RoleTh);
+            EnsureColumnScope(cell.Element);
+            promoted++;
+        }
+
+        return promoted;
+    }
+
+    private static void EnsureColumnScope(PdfDictionary cell)
+    {
+        var attrsObj = cell.Get(PdfName.A);
+        var attrs = Dereference(attrsObj);
+
+        if (attrs is null)
+        {
+            cell.Put(PdfName.A, CreateColumnScopeAttributeDict());
+            return;
+        }
+
+        if (attrs is PdfDictionary dict)
+        {
+            if (TrySetColumnScope(dict))
+            {
+                return;
+            }
+
+            var array = new PdfArray();
+            array.Add(dict);
+            array.Add(CreateColumnScopeAttributeDict());
+            cell.Put(PdfName.A, array);
+            return;
+        }
+
+        if (attrs is PdfArray attrArray)
+        {
+            foreach (var item in attrArray)
+            {
+                if (Dereference(item) is PdfDictionary itemDict && TrySetColumnScope(itemDict))
+                {
+                    return;
+                }
+            }
+
+            attrArray.Add(CreateColumnScopeAttributeDict());
+            return;
+        }
+
+        var fallback = new PdfArray();
+        fallback.Add(attrsObj);
+        fallback.Add(CreateColumnScopeAttributeDict());
+        cell.Put(PdfName.A, fallback);
+    }
+
+    private static bool TrySetColumnScope(PdfDictionary dict)
+    {
+        var owner = dict.GetAsName(AttrOwnerKey);
+        if (owner is not null && !AttrOwnerTable.Equals(owner))
+        {
+            return false;
+        }
+
+        dict.Put(AttrOwnerKey, AttrOwnerTable);
+        dict.Put(AttrScopeKey, AttrScopeColumn);
+        return true;
+    }
+
+    private static PdfDictionary CreateColumnScopeAttributeDict()
+    {
+        var dict = new PdfDictionary();
+        dict.Put(AttrOwnerKey, AttrOwnerTable);
+        dict.Put(AttrScopeKey, AttrScopeColumn);
+        return dict;
+    }
+
+    private static bool CollectTableRows(
+        PdfDictionary table,
+        List<PdfDictionary> rows,
+        CancellationToken cancellationToken)
+    {
+        var hasNestedTable = false;
+        foreach (var child in ListDirectStructElementChildren(table))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var role = child.GetAsName(PdfName.S);
+            if (RoleTr.Equals(role))
+            {
+                rows.Add(child);
+                continue;
+            }
+
+            if (RoleTable.Equals(role))
+            {
+                hasNestedTable = true;
+                continue;
+            }
+
+            if (RoleTHead.Equals(role) || RoleTBody.Equals(role) || RoleTFoot.Equals(role))
+            {
+                hasNestedTable |= CollectRowsFromTableSection(child, rows, cancellationToken);
+            }
+        }
+
+        return hasNestedTable;
+    }
+
+    private static bool CollectRowsFromTableSection(
+        PdfDictionary section,
+        List<PdfDictionary> rows,
+        CancellationToken cancellationToken)
+    {
+        var hasNestedTable = false;
+        foreach (var child in ListDirectStructElementChildren(section))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var role = child.GetAsName(PdfName.S);
+            if (RoleTr.Equals(role))
+            {
+                rows.Add(child);
+            }
+            else if (RoleTable.Equals(role))
+            {
+                hasNestedTable = true;
+            }
+        }
+
+        return hasNestedTable;
+    }
+
+    private static string BuildFirstRowSnippet(IReadOnlyList<TableRowInventory> rows)
+    {
+        if (rows.Count == 0 || rows[0].Cells.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var snippet = string.Join(" | ", rows[0].Cells.Select(c => c.Text).Where(t => !string.IsNullOrWhiteSpace(t)));
+        if (snippet.Length > 160)
+        {
+            snippet = snippet[..160].Trim();
+        }
+
+        return snippet;
+    }
+
+    private static string? TryExtractCellText(
+        PdfDocument pdf,
+        PdfDictionary cell,
+        Dictionary<int, int> pageObjNumToPageNumber,
+        Dictionary<int, Dictionary<int, string>> pageMcidTextCache,
+        CancellationToken cancellationToken)
+    {
+        var alt = cell.GetAsString(PdfName.Alt)?.ToUnicodeString();
+        alt = RemediationHelpers.NormalizeWhitespace(alt ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(alt))
+        {
+            return alt;
+        }
+
+        var refs = ListMarkedContentRefs(cell, pageObjNumToPageNumber);
+        if (refs.Count == 0)
+        {
+            return null;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var (pageNumber, mcid) in refs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (mcid < 0)
+            {
+                continue;
+            }
+
+            var textByMcid = GetOrScanPageMcidText(pdf, pageNumber, pageMcidTextCache, cancellationToken);
+            if (textByMcid.TryGetValue(mcid, out var text) && !string.IsNullOrWhiteSpace(text))
+            {
+                AppendWithWordBoundary(sb, text);
+            }
+        }
+
+        var combined = RemediationHelpers.NormalizeWhitespace(sb.ToString());
+        return string.IsNullOrWhiteSpace(combined) ? null : combined;
+    }
+
+    private static List<(int pageNumber, int mcid)> ListMarkedContentRefs(
+        PdfDictionary structElem,
+        Dictionary<int, int> pageObjNumToPageNumber)
+    {
+        var defaultPageDict = structElem.GetAsDictionary(PdfName.Pg);
+        var kids = structElem.Get(PdfName.K);
+        if (kids is null)
+        {
+            return [];
+        }
+
+        var results = new List<(int pageNumber, int mcid)>();
+        CollectMarkedContentRefsRecursive(kids, defaultPageDict, pageObjNumToPageNumber, results);
+        return results;
+    }
+
+    private static void CollectMarkedContentRefsRecursive(
+        PdfObject node,
+        PdfDictionary? inheritedPageDict,
+        Dictionary<int, int> pageObjNumToPageNumber,
+        List<(int pageNumber, int mcid)> results)
+    {
+        var dereferenced = Dereference(node);
+        if (dereferenced is null)
+        {
+            return;
+        }
+
+        node = dereferenced;
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                CollectMarkedContentRefsRecursive(item, inheritedPageDict, pageObjNumToPageNumber, results);
+            }
+
+            return;
+        }
+
+        if (node is PdfNumber num)
+        {
+            var pageNumber = TryResolvePageNumber(inheritedPageDict, pageObjNumToPageNumber);
+            if (pageNumber is not null)
+            {
+                results.Add((pageNumber.Value, num.IntValue()));
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        if (IsStructElemDictionary(dict))
+        {
+            var nestedPageDict = dict.GetAsDictionary(PdfName.Pg) ?? inheritedPageDict;
+            var kids = dict.Get(PdfName.K);
+            if (kids is not null)
+            {
+                CollectMarkedContentRefsRecursive(kids, nestedPageDict, pageObjNumToPageNumber, results);
+            }
+
+            return;
+        }
+
+        var pageDict = dict.GetAsDictionary(PdfName.Pg) ?? inheritedPageDict;
+        var mcidNum = dict.GetAsNumber(PdfName.MCID);
+        if (mcidNum is not null)
+        {
+            var pageNumber = TryResolvePageNumber(pageDict, pageObjNumToPageNumber);
+            if (pageNumber is not null)
+            {
+                results.Add((pageNumber.Value, mcidNum.IntValue()));
+            }
+        }
+    }
+
+    private static Dictionary<int, string> GetOrScanPageMcidText(
+        PdfDocument pdf,
+        int pageNumber,
+        Dictionary<int, Dictionary<int, string>> cache,
+        CancellationToken cancellationToken)
+    {
+        if (cache.TryGetValue(pageNumber, out var existing))
+        {
+            return existing;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var page = pdf.GetPage(pageNumber);
+        var listener = new McidTextListener();
+        new PdfCanvasProcessor(listener).ProcessPageContent(page);
+        var textByMcid = listener.GetTextByMcid();
+
+        cache[pageNumber] = textByMcid;
+        return textByMcid;
+    }
+
+    private static void AppendWithWordBoundary(StringBuilder sb, string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        text = text.Trim();
+
+        if (sb.Length > 0 && !char.IsWhiteSpace(sb[^1]) && text.Length > 0 && !char.IsWhiteSpace(text[0]))
+        {
+            sb.Append(' ');
+        }
+
+        sb.Append(text);
+    }
+
+    private static int? TryResolvePageNumber(PdfDictionary? pageDict, Dictionary<int, int> pageObjNumToPageNumber)
+    {
+        if (pageDict is null)
+        {
+            return null;
+        }
+
+        var pageRef = pageDict.GetIndirectReference();
+        if (pageRef is null)
+        {
+            return null;
+        }
+
+        return pageObjNumToPageNumber.TryGetValue(pageRef.GetObjNumber(), out var pageNumber) ? pageNumber : null;
+    }
+
+    private static Dictionary<int, int> BuildPageObjectNumberToPageNumberMap(PdfDocument pdf)
+    {
+        var map = new Dictionary<int, int>();
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            var pageRef = pdf.GetPage(pageNumber).GetPdfObject().GetIndirectReference();
+            if (pageRef is null)
+            {
+                continue;
+            }
+
+            map[pageRef.GetObjNumber()] = pageNumber;
+        }
+
+        return map;
     }
 
     private static void DemoteTableAndDescendants(PdfDictionary table, CancellationToken cancellationToken)
@@ -182,7 +679,7 @@ internal static class PdfTableRoleRemediator
 
         table.Put(PdfName.S, RoleDiv);
 
-        var stack = new Stack<PdfObject>();
+        var stack = new Stack<PdfObject?>();
         stack.Push(table.Get(PdfName.K));
 
         while (stack.Count > 0)
@@ -195,7 +692,13 @@ internal static class PdfTableRoleRemediator
                 continue;
             }
 
-            node = Dereference(node);
+            var dereferenced = Dereference(node);
+            if (dereferenced is null)
+            {
+                continue;
+            }
+
+            node = dereferenced;
             if (node is PdfArray array)
             {
                 foreach (var item in array)
@@ -228,13 +731,38 @@ internal static class PdfTableRoleRemediator
         }
     }
 
+    private static List<PdfDictionary> ListStructElementsByRole(
+        PdfDocument pdf,
+        PdfName role,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var catalogDict = pdf.GetCatalog().GetPdfObject();
+        var structTreeRootDict = catalogDict.GetAsDictionary(PdfName.StructTreeRoot);
+        if (structTreeRootDict is null)
+        {
+            return [];
+        }
+
+        var rootKids = structTreeRootDict.Get(PdfName.K);
+        if (rootKids is null)
+        {
+            return [];
+        }
+
+        var results = new List<PdfDictionary>();
+        TraverseTagTreeForList(rootKids, role, results, cancellationToken);
+        return results;
+    }
+
     private static List<PdfDictionary> ListDescendantStructElementsByRole(
         PdfDictionary root,
         PdfName role,
         CancellationToken cancellationToken)
     {
         var results = new List<PdfDictionary>();
-        var stack = new Stack<PdfObject>();
+        var stack = new Stack<PdfObject?>();
         stack.Push(root.Get(PdfName.K));
 
         while (stack.Count > 0)
@@ -247,8 +775,13 @@ internal static class PdfTableRoleRemediator
                 continue;
             }
 
-            node = Dereference(node);
+            var dereferenced = Dereference(node);
+            if (dereferenced is null)
+            {
+                continue;
+            }
 
+            node = dereferenced;
             if (node is PdfArray array)
             {
                 foreach (var item in array)
@@ -279,6 +812,49 @@ internal static class PdfTableRoleRemediator
         return results;
     }
 
+    private static void TraverseTagTreeForList(
+        PdfObject node,
+        PdfName role,
+        List<PdfDictionary> results,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dereferenced = Dereference(node);
+        if (dereferenced is null)
+        {
+            return;
+        }
+
+        node = dereferenced;
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                TraverseTagTreeForList(item, role, results, cancellationToken);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        if (dict.ContainsKey(PdfName.S) && role.Equals(dict.GetAsName(PdfName.S)))
+        {
+            results.Add(dict);
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            TraverseTagTreeForList(kids, role, results, cancellationToken);
+        }
+    }
+
     private static List<PdfDictionary> ListDirectStructElementChildren(PdfDictionary structElem)
     {
         var kids = structElem.Get(PdfName.K);
@@ -287,14 +863,13 @@ internal static class PdfTableRoleRemediator
             return [];
         }
 
-        kids = Dereference(kids);
-
-        if (kids is PdfDictionary kidDict)
+        var dereferenced = Dereference(kids);
+        if (dereferenced is PdfDictionary kidDict)
         {
             return kidDict.ContainsKey(PdfName.S) ? [kidDict] : [];
         }
 
-        if (kids is not PdfArray array)
+        if (dereferenced is not PdfArray array)
         {
             return [];
         }
@@ -302,8 +877,8 @@ internal static class PdfTableRoleRemediator
         var results = new List<PdfDictionary>(array.Size());
         foreach (var item in array)
         {
-            var deref = Dereference(item);
-            if (deref is PdfDictionary itemDict && itemDict.ContainsKey(PdfName.S))
+            var itemDeref = Dereference(item);
+            if (itemDeref is PdfDictionary itemDict && itemDict.ContainsKey(PdfName.S))
             {
                 results.Add(itemDict);
             }
@@ -312,8 +887,143 @@ internal static class PdfTableRoleRemediator
         return results;
     }
 
-    private static PdfObject Dereference(PdfObject obj)
+    private static bool IsStructElemDictionary(PdfDictionary dict) => dict.ContainsKey(PdfName.S);
+
+    private sealed record TableInventory(
+        PdfDictionary Element,
+        IReadOnlyList<TableRowInventory> Rows,
+        int HeaderCellCount,
+        int MaxColumnCount,
+        bool HasNestedTable,
+        string FirstRowSnippet)
     {
+        public int RowCount => Rows.Count;
+
+        public PdfTableClassificationRequest ToClassificationRequest(string? primaryLanguage) =>
+            new(
+                RowCount,
+                MaxColumnCount,
+                HasNestedTable,
+                Rows
+                    .Select(r => (IReadOnlyList<string>)r.Cells.Select(c => c.Text).ToList())
+                    .ToList(),
+                primaryLanguage);
+    }
+
+    private sealed record TableRowInventory(PdfDictionary Element, IReadOnlyList<TableCellInventory> Cells);
+
+    private sealed record TableCellInventory(PdfDictionary Element, PdfName Role, string Text);
+
+    private sealed class McidTextListener : IEventListener
+    {
+        private readonly Dictionary<int, McidTextState> _byMcid = new();
+
+        public void EventOccurred(IEventData data, EventType type)
+        {
+            if (type != EventType.RENDER_TEXT || data is not TextRenderInfo tri)
+            {
+                return;
+            }
+
+            var mcid = tri.GetMcid();
+            if (mcid < 0)
+            {
+                return;
+            }
+
+            var text = tri.GetActualText() ?? tri.GetText() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            if (!_byMcid.TryGetValue(mcid, out var state))
+            {
+                state = new McidTextState();
+                _byMcid[mcid] = state;
+            }
+
+            state.Append(tri, text);
+        }
+
+        public ICollection<EventType> GetSupportedEvents() => new[] { EventType.RENDER_TEXT };
+
+        public Dictionary<int, string> GetTextByMcid()
+        {
+            var result = new Dictionary<int, string>();
+            foreach (var (mcid, state) in _byMcid)
+            {
+                var text = RemediationHelpers.NormalizeWhitespace(state.Text.ToString());
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    result[mcid] = text;
+                }
+            }
+
+            return result;
+        }
+
+        private sealed class McidTextState
+        {
+            public StringBuilder Text { get; } = new();
+
+            private Vector? _lastBaselineEnd;
+
+            public void Append(TextRenderInfo tri, string text)
+            {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    return;
+                }
+
+                var baseline = tri.GetBaseline();
+                var start = baseline.GetStartPoint();
+                var end = baseline.GetEndPoint();
+
+                TryAppendSpaceIfGapIndicatesWordBoundary(tri, start, text);
+                Text.Append(text);
+                _lastBaselineEnd = end;
+            }
+
+            private void TryAppendSpaceIfGapIndicatesWordBoundary(TextRenderInfo tri, Vector start, string text)
+            {
+                if (Text.Length == 0 || _lastBaselineEnd is null)
+                {
+                    return;
+                }
+
+                var lastChar = Text[^1];
+                var firstChar = text[0];
+                if (char.IsWhiteSpace(lastChar) || char.IsWhiteSpace(firstChar))
+                {
+                    return;
+                }
+
+                var spaceWidth = tri.GetSingleSpaceWidth();
+                if (spaceWidth <= 0)
+                {
+                    spaceWidth = 3f;
+                }
+
+                var dx = start.Get(0) - _lastBaselineEnd.Get(0);
+                var dy = start.Get(1) - _lastBaselineEnd.Get(1);
+                var distance = MathF.Sqrt((dx * dx) + (dy * dy));
+
+                if (distance > (spaceWidth * 0.5f))
+                {
+                    Text.Append(' ');
+                }
+            }
+        }
+    }
+
+    private static PdfObject? Dereference(PdfObject? obj)
+    {
+        if (obj is null)
+        {
+            return null;
+        }
+
         if (obj is PdfIndirectReference reference)
         {
             return reference.GetRefersTo(true);

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -887,7 +887,7 @@ internal static class PdfTableRoleRemediator
             if (dict.ContainsKey(PdfName.S))
             {
                 var role = dict.GetAsName(PdfName.S);
-                if (RoleTr.Equals(role) || RoleTd.Equals(role) || RoleTh.Equals(role) || RoleTable.Equals(role))
+                if (IsTableStructureRole(role))
                 {
                     dict.Put(PdfName.S, RoleDiv);
                 }
@@ -900,6 +900,15 @@ internal static class PdfTableRoleRemediator
             }
         }
     }
+
+    private static bool IsTableStructureRole(PdfName? role) =>
+        RoleTable.Equals(role)
+        || RoleTHead.Equals(role)
+        || RoleTBody.Equals(role)
+        || RoleTFoot.Equals(role)
+        || RoleTr.Equals(role)
+        || RoleTh.Equals(role)
+        || RoleTd.Equals(role);
 
     private static List<PdfDictionary> ListStructElementsByRole(
         PdfDocument pdf,

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -10,8 +10,8 @@ namespace server.core.Remediate;
 
 internal enum PdfNoHeaderTableRemediationAction
 {
-    PromotedFirstRow,
-    DemotedLayoutTable,
+    PromotedHeaderRow,
+    DemotedNoHeaderTable,
     LeftUnchanged,
 }
 
@@ -34,12 +34,6 @@ internal static class PdfTableRoleRemediator
     private static readonly PdfName RoleTh = new("TH");
     private static readonly PdfName RoleTd = new("TD");
     private static readonly PdfName RoleDiv = new("Div");
-    private static readonly PdfName AttrOwnerKey = new("O");
-    private static readonly PdfName AttrOwnerTable = new("Table");
-    private static readonly PdfName AttrScopeKey = new("Scope");
-    private static readonly PdfName AttrScopeColumn = new("Column");
-    private static readonly PdfName AttrHeadersKey = new("Headers");
-    private static readonly PdfName StructElemIdKey = new("ID");
 
     public static int DemoteLikelyLayoutTables(
         PdfDocument pdf,
@@ -80,8 +74,7 @@ internal static class PdfTableRoleRemediator
         PdfDocument pdf,
         IPdfTableClassificationService tableClassificationService,
         string? primaryLanguage,
-        bool promoteFirstRowHeadersForNoHeaderTables,
-        bool demoteLikelyFormLayoutTables,
+        bool demoteNoHeaderTables,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -91,7 +84,7 @@ internal static class PdfTableRoleRemediator
             return [];
         }
 
-        if (!promoteFirstRowHeadersForNoHeaderTables && !demoteLikelyFormLayoutTables)
+        if (!demoteNoHeaderTables)
         {
             return [];
         }
@@ -137,57 +130,36 @@ internal static class PdfTableRoleRemediator
             var request = inventory.ToClassificationRequest(primaryLanguage);
             var classification = await tableClassificationService.ClassifyAsync(request, cancellationToken);
             var confidence = Math.Clamp(classification.Confidence, 0, 1);
+            var isConfidentDataTable = classification.Kind == PdfTableKind.DataTable
+                && confidence >= MinClassifierConfidence;
 
-            if (classification.Kind == PdfTableKind.DataTable
-                && confidence >= MinClassifierConfidence
-                && promoteFirstRowHeadersForNoHeaderTables)
+            if (isConfidentDataTable)
             {
-                var promoted = PromoteHeaderRowCellsToHeaders(inventory, cancellationToken);
+                var promoted = PromoteHeaderRowToTableHead(inventory, cancellationToken);
                 results.Add(
                     new PdfNoHeaderTableRemediation(
-                        promoted > 0
-                            ? PdfNoHeaderTableRemediationAction.PromotedFirstRow
+                        promoted
+                            ? PdfNoHeaderTableRemediationAction.PromotedHeaderRow
                             : PdfNoHeaderTableRemediationAction.LeftUnchanged,
                         inventory.RowCount,
                         inventory.MaxColumnCount,
                         inventory.FirstRowSnippet,
-                        promoted > 0
-                            ? "classified as data table; promoted header row cells to TH"
-                            : "classified as data table but no usable header row cells were available to promote"));
+                        promoted
+                            ? "classified as data table; moved header row into THead and promoted cells to TH"
+                            : "classified as data table but no usable header row was available to promote"));
                 continue;
             }
 
-            if (classification.Kind == PdfTableKind.DataTable && confidence < MinClassifierConfidence)
-            {
-                classification = classification with
-                {
-                    Kind = PdfTableKind.NotDataTable,
-                    Reason =
-                        $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; treating as non-data",
-                };
-            }
-
-            if (classification.Kind == PdfTableKind.NotDataTable && demoteLikelyFormLayoutTables)
-            {
-                DemoteTableAndDescendants(table, cancellationToken);
-                results.Add(
-                    new PdfNoHeaderTableRemediation(
-                        PdfNoHeaderTableRemediationAction.DemotedLayoutTable,
-                        inventory.RowCount,
-                        inventory.MaxColumnCount,
-                        inventory.FirstRowSnippet,
-                        "classified as non-data table; demoted table roles"));
-                continue;
-            }
-
+            DemoteTableAndDescendants(table, cancellationToken);
             results.Add(
-                CreateUnchangedResult(
-                    inventory,
-                    classification.Kind switch
-                    {
-                        PdfTableKind.DataTable => "classified as data table but first-row header promotion is disabled",
-                        _ => "classified as non-data table but form-layout demotion is disabled",
-                    }));
+                new PdfNoHeaderTableRemediation(
+                    PdfNoHeaderTableRemediationAction.DemotedNoHeaderTable,
+                    inventory.RowCount,
+                    inventory.MaxColumnCount,
+                    inventory.FirstRowSnippet,
+                    classification.Kind == PdfTableKind.DataTable
+                        ? $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; demoted table roles"
+                        : "classified as non-data table; demoted table roles"));
         }
 
         return results;
@@ -322,40 +294,50 @@ internal static class PdfTableRoleRemediator
         return new TableInventory(table, rows, headerCellCount, maxColumnCount, hasNestedTable, firstRowSnippet);
     }
 
-    private static int PromoteHeaderRowCellsToHeaders(TableInventory inventory, CancellationToken cancellationToken)
+    private static bool PromoteHeaderRowToTableHead(TableInventory inventory, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var headerRowIndex = SelectHeaderRowIndex(inventory);
         if (headerRowIndex is null)
         {
-            return 0;
+            return false;
         }
 
-        var headerRow = inventory.Rows[headerRowIndex.Value];
-        var headerIdsByColumn = new List<string>();
-        var promoted = 0;
-        for (var colIndex = 0; colIndex < headerRow.Cells.Count; colIndex++)
+        var headerRow = inventory.Rows[headerRowIndex.Value].Element;
+        var headerRowParent = FindStructElementParent(inventory.Element, headerRow, cancellationToken);
+        if (headerRowParent is null)
+        {
+            return false;
+        }
+
+        var headerCellsPromoted = 0;
+        foreach (var child in ListDirectStructElementChildren(headerRow))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var cell = headerRow.Cells[colIndex];
-            if (!RoleTd.Equals(cell.Role))
+            if (RoleTd.Equals(child.GetAsName(PdfName.S)))
             {
-                if (RoleTh.Equals(cell.Role))
-                {
-                    headerIdsByColumn.Add(EnsureHeaderId(cell.Element));
-                }
-
-                continue;
+                child.Put(PdfName.S, RoleTh);
+                headerCellsPromoted++;
             }
-
-            cell.Element.Put(PdfName.S, RoleTh);
-            EnsureColumnScope(cell.Element);
-            headerIdsByColumn.Add(EnsureHeaderId(cell.Element));
-            promoted++;
         }
 
-        AssociateDataCellsWithHeaders(inventory, headerRowIndex.Value, headerIdsByColumn, cancellationToken);
-        return promoted;
+        if (headerCellsPromoted == 0)
+        {
+            return false;
+        }
+
+        var thead = CreateStructElement(RoleTHead, inventory.Element);
+        if (!MoveStructElementChild(headerRowParent, thead, headerRow))
+        {
+            return false;
+        }
+
+        InsertTableHead(inventory.Element, thead);
+        headerRow.Put(PdfName.P, thead);
+        WrapDirectRowsInTableBody(inventory.Element, cancellationToken);
+        return true;
     }
 
     private static int? SelectHeaderRowIndex(TableInventory inventory)
@@ -377,193 +359,223 @@ internal static class PdfTableRoleRemediator
         return inventory.Rows[0].Cells.Count > 0 ? 0 : null;
     }
 
-    private static string EnsureHeaderId(PdfDictionary headerCell)
+    private static PdfDictionary CreateStructElement(PdfName role, PdfDictionary parent)
     {
-        var existing = headerCell.GetAsString(StructElemIdKey)?.ToUnicodeString();
-        existing = RemediationHelpers.NormalizeWhitespace(existing ?? string.Empty);
-        if (!string.IsNullOrWhiteSpace(existing))
+        var structElem = new PdfDictionary();
+        structElem.Put(PdfName.Type, new PdfName("StructElem"));
+        structElem.Put(PdfName.S, role);
+        structElem.Put(PdfName.P, parent);
+
+        var page = parent.Get(PdfName.Pg);
+        if (page is not null)
         {
-            return existing;
+            structElem.Put(PdfName.Pg, page);
         }
 
-        var id = $"rbl-th-{Guid.NewGuid():N}";
-        headerCell.Put(StructElemIdKey, new PdfString(id));
-        return id;
+        return structElem;
     }
 
-    private static void AssociateDataCellsWithHeaders(
-        TableInventory inventory,
-        int headerRowIndex,
-        IReadOnlyList<string> headerIdsByColumn,
+    private static PdfDictionary? FindStructElementParent(
+        PdfDictionary root,
+        PdfDictionary target,
         CancellationToken cancellationToken)
     {
-        if (headerIdsByColumn.Count == 0)
+        var stack = new Stack<PdfDictionary>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
         {
-            return;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var current = stack.Pop();
+            foreach (var child in ListDirectStructElementChildren(current))
+            {
+                if (IsSameStructElement(child, target))
+                {
+                    return current;
+                }
+
+                stack.Push(child);
+            }
         }
 
-        for (var rowIndex = 0; rowIndex < inventory.Rows.Count; rowIndex++)
-        {
-            var row = inventory.Rows[rowIndex];
-            for (var colIndex = 0; colIndex < row.Cells.Count; colIndex++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+        return null;
+    }
 
-                if (rowIndex == headerRowIndex || colIndex >= headerIdsByColumn.Count)
+    private static bool MoveStructElementChild(PdfDictionary fromParent, PdfDictionary toParent, PdfDictionary child)
+    {
+        var childObject = RemoveStructElementChild(fromParent, child);
+        if (childObject is null)
+        {
+            return false;
+        }
+
+        var kids = new PdfArray();
+        kids.Add(childObject);
+        toParent.Put(PdfName.K, kids);
+        return true;
+    }
+
+    private static PdfObject? RemoveStructElementChild(PdfDictionary parent, PdfDictionary child)
+    {
+        var kids = parent.Get(PdfName.K);
+        if (kids is null)
+        {
+            return null;
+        }
+
+        var dereferencedKids = Dereference(kids);
+        if (dereferencedKids is PdfArray array)
+        {
+            for (var i = 0; i < array.Size(); i++)
+            {
+                var item = array.Get(i);
+                if (!IsSameStructElement(item, child))
                 {
                     continue;
                 }
 
-                var cell = row.Cells[colIndex];
-                if (RoleTd.Equals(cell.Role))
-                {
-                    EnsureCellHeaders(cell.Element, [headerIdsByColumn[colIndex]]);
-                }
+                array.Remove(i);
+                return item;
             }
+
+            return null;
         }
+
+        if (!IsSameStructElement(dereferencedKids ?? kids, child))
+        {
+            return null;
+        }
+
+        parent.Remove(PdfName.K);
+        return kids;
     }
 
-    private static void EnsureColumnScope(PdfDictionary cell)
+    private static void InsertTableHead(PdfDictionary table, PdfDictionary thead)
     {
-        var attrsObj = cell.Get(PdfName.A);
-        var attrs = Dereference(attrsObj);
-
-        if (attrs is null)
+        var kids = table.Get(PdfName.K);
+        if (kids is null)
         {
-            cell.Put(PdfName.A, CreateColumnScopeAttributeDict());
+            var singleKid = new PdfArray();
+            singleKid.Add(thead);
+            table.Put(PdfName.K, singleKid);
             return;
         }
 
-        if (attrs is PdfDictionary dict)
+        var dereferencedKids = Dereference(kids);
+        if (dereferencedKids is PdfArray array)
         {
-            if (TrySetColumnScope(dict))
+            var insertIndex = 0;
+            while (insertIndex < array.Size())
             {
-                return;
-            }
-
-            var array = new PdfArray();
-            array.Add(dict);
-            array.Add(CreateColumnScopeAttributeDict());
-            cell.Put(PdfName.A, array);
-            return;
-        }
-
-        if (attrs is PdfArray attrArray)
-        {
-            foreach (var item in attrArray)
-            {
-                if (Dereference(item) is PdfDictionary itemDict && TrySetColumnScope(itemDict))
+                var item = Dereference(array.Get(insertIndex));
+                if (item is PdfDictionary dict && RoleTHead.Equals(dict.GetAsName(PdfName.S)))
                 {
-                    return;
+                    insertIndex++;
+                    continue;
                 }
+
+                break;
             }
 
-            attrArray.Add(CreateColumnScopeAttributeDict());
+            array.Add(insertIndex, thead);
             return;
         }
 
-        var fallback = new PdfArray();
-        fallback.Add(attrsObj);
-        fallback.Add(CreateColumnScopeAttributeDict());
-        cell.Put(PdfName.A, fallback);
+        var newKids = new PdfArray();
+        newKids.Add(thead);
+        newKids.Add(kids);
+        table.Put(PdfName.K, newKids);
     }
 
-    private static bool TrySetColumnScope(PdfDictionary dict)
+    private static void WrapDirectRowsInTableBody(PdfDictionary table, CancellationToken cancellationToken)
     {
-        var owner = dict.GetAsName(AttrOwnerKey);
-        if (owner is not null && !AttrOwnerTable.Equals(owner))
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var kids = Dereference(table.Get(PdfName.K));
+        if (kids is not PdfArray array)
+        {
+            return;
+        }
+
+        var rowKids = new List<PdfObject>();
+        var rowIndexes = new List<int>();
+        for (var i = 0; i < array.Size(); i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var item = array.Get(i);
+            if (Dereference(item) is PdfDictionary dict && RoleTr.Equals(dict.GetAsName(PdfName.S)))
+            {
+                rowKids.Add(item);
+                rowIndexes.Add(i);
+            }
+        }
+
+        if (rowKids.Count == 0)
+        {
+            return;
+        }
+
+        var tbody = CreateStructElement(RoleTBody, table);
+        var tbodyKids = new PdfArray();
+        foreach (var rowKid in rowKids)
+        {
+            tbodyKids.Add(rowKid);
+            if (Dereference(rowKid) is PdfDictionary rowDict)
+            {
+                rowDict.Put(PdfName.P, tbody);
+            }
+        }
+
+        tbody.Put(PdfName.K, tbodyKids);
+
+        for (var i = rowIndexes.Count - 1; i >= 0; i--)
+        {
+            array.Remove(rowIndexes[i]);
+        }
+
+        var insertIndex = 0;
+        while (insertIndex < array.Size())
+        {
+            var item = Dereference(array.Get(insertIndex));
+            if (item is PdfDictionary dict && RoleTHead.Equals(dict.GetAsName(PdfName.S)))
+            {
+                insertIndex++;
+                continue;
+            }
+
+            break;
+        }
+
+        array.Add(insertIndex, tbody);
+    }
+
+    private static bool IsSameStructElement(PdfObject? candidate, PdfDictionary target)
+    {
+        var targetRef = target.GetIndirectReference();
+        if (targetRef is not null && candidate is PdfIndirectReference candidateRef)
+        {
+            return candidateRef.GetObjNumber() == targetRef.GetObjNumber()
+                && candidateRef.GetGenNumber() == targetRef.GetGenNumber();
+        }
+
+        var dereferenced = Dereference(candidate);
+        if (dereferenced is not PdfDictionary candidateDict)
         {
             return false;
         }
 
-        dict.Put(AttrOwnerKey, AttrOwnerTable);
-        dict.Put(AttrScopeKey, AttrScopeColumn);
-        return true;
-    }
-
-    private static PdfDictionary CreateColumnScopeAttributeDict()
-    {
-        var dict = new PdfDictionary();
-        dict.Put(AttrOwnerKey, AttrOwnerTable);
-        dict.Put(AttrScopeKey, AttrScopeColumn);
-        return dict;
-    }
-
-    private static void EnsureCellHeaders(PdfDictionary cell, IReadOnlyList<string> headerIds)
-    {
-        var attrsObj = cell.Get(PdfName.A);
-        var attrs = Dereference(attrsObj);
-
-        if (attrs is null)
+        if (ReferenceEquals(candidateDict, target))
         {
-            cell.Put(PdfName.A, CreateHeadersAttributeDict(headerIds));
-            return;
+            return true;
         }
 
-        if (attrs is PdfDictionary dict)
-        {
-            if (TrySetHeaders(dict, headerIds))
-            {
-                return;
-            }
-
-            var array = new PdfArray();
-            array.Add(dict);
-            array.Add(CreateHeadersAttributeDict(headerIds));
-            cell.Put(PdfName.A, array);
-            return;
-        }
-
-        if (attrs is PdfArray attrArray)
-        {
-            foreach (var item in attrArray)
-            {
-                if (Dereference(item) is PdfDictionary itemDict && TrySetHeaders(itemDict, headerIds))
-                {
-                    return;
-                }
-            }
-
-            attrArray.Add(CreateHeadersAttributeDict(headerIds));
-            return;
-        }
-
-        var fallback = new PdfArray();
-        fallback.Add(attrsObj);
-        fallback.Add(CreateHeadersAttributeDict(headerIds));
-        cell.Put(PdfName.A, fallback);
-    }
-
-    private static bool TrySetHeaders(PdfDictionary dict, IReadOnlyList<string> headerIds)
-    {
-        var owner = dict.GetAsName(AttrOwnerKey);
-        if (owner is not null && !AttrOwnerTable.Equals(owner))
-        {
-            return false;
-        }
-
-        dict.Put(AttrOwnerKey, AttrOwnerTable);
-        dict.Put(AttrHeadersKey, CreateHeaderIdArray(headerIds));
-        return true;
-    }
-
-    private static PdfDictionary CreateHeadersAttributeDict(IReadOnlyList<string> headerIds)
-    {
-        var dict = new PdfDictionary();
-        dict.Put(AttrOwnerKey, AttrOwnerTable);
-        dict.Put(AttrHeadersKey, CreateHeaderIdArray(headerIds));
-        return dict;
-    }
-
-    private static PdfArray CreateHeaderIdArray(IReadOnlyList<string> headerIds)
-    {
-        var array = new PdfArray();
-        foreach (var id in headerIds)
-        {
-            array.Add(new PdfString(id));
-        }
-
-        return array;
+        var candidateRefFromDict = candidateDict.GetIndirectReference();
+        return targetRef is not null
+            && candidateRefFromDict is not null
+            && candidateRefFromDict.GetObjNumber() == targetRef.GetObjNumber()
+            && candidateRefFromDict.GetGenNumber() == targetRef.GetGenNumber();
     }
 
     private static bool CollectTableRows(

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -38,6 +38,8 @@ internal static class PdfTableRoleRemediator
     private static readonly PdfName AttrOwnerTable = new("Table");
     private static readonly PdfName AttrScopeKey = new("Scope");
     private static readonly PdfName AttrScopeColumn = new("Column");
+    private static readonly PdfName AttrHeadersKey = new("Headers");
+    private static readonly PdfName StructElemIdKey = new("ID");
 
     public static int DemoteLikelyLayoutTables(
         PdfDocument pdf,
@@ -135,18 +137,12 @@ internal static class PdfTableRoleRemediator
             var request = inventory.ToClassificationRequest(primaryLanguage);
             var classification = await tableClassificationService.ClassifyAsync(request, cancellationToken);
             var confidence = Math.Clamp(classification.Confidence, 0, 1);
-            if (confidence < MinClassifierConfidence)
-            {
-                results.Add(
-                    CreateUnchangedResult(
-                        inventory,
-                        $"left unchanged; table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}"));
-                continue;
-            }
 
-            if (classification.Kind == PdfTableKind.DataTable && promoteFirstRowHeadersForNoHeaderTables)
+            if (classification.Kind == PdfTableKind.DataTable
+                && confidence >= MinClassifierConfidence
+                && promoteFirstRowHeadersForNoHeaderTables)
             {
-                var promoted = PromoteFirstRowCellsToHeaders(inventory, cancellationToken);
+                var promoted = PromoteHeaderRowCellsToHeaders(inventory, cancellationToken);
                 results.Add(
                     new PdfNoHeaderTableRemediation(
                         promoted > 0
@@ -156,12 +152,22 @@ internal static class PdfTableRoleRemediator
                         inventory.MaxColumnCount,
                         inventory.FirstRowSnippet,
                         promoted > 0
-                            ? "classified as data table; promoted first row cells to TH"
-                            : "classified as data table but no first-row TD cells were available to promote"));
+                            ? "classified as data table; promoted header row cells to TH"
+                            : "classified as data table but no usable header row cells were available to promote"));
                 continue;
             }
 
-            if (classification.Kind == PdfTableKind.LayoutOrFormTable && demoteLikelyFormLayoutTables)
+            if (classification.Kind == PdfTableKind.DataTable && confidence < MinClassifierConfidence)
+            {
+                classification = classification with
+                {
+                    Kind = PdfTableKind.NotDataTable,
+                    Reason =
+                        $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; treating as non-data",
+                };
+            }
+
+            if (classification.Kind == PdfTableKind.NotDataTable && demoteLikelyFormLayoutTables)
             {
                 DemoteTableAndDescendants(table, cancellationToken);
                 results.Add(
@@ -170,7 +176,7 @@ internal static class PdfTableRoleRemediator
                         inventory.RowCount,
                         inventory.MaxColumnCount,
                         inventory.FirstRowSnippet,
-                        "classified as layout/form table; demoted table roles"));
+                        "classified as non-data table; demoted table roles"));
                 continue;
             }
 
@@ -180,8 +186,7 @@ internal static class PdfTableRoleRemediator
                     classification.Kind switch
                     {
                         PdfTableKind.DataTable => "classified as data table but first-row header promotion is disabled",
-                        PdfTableKind.LayoutOrFormTable => "classified as layout/form table but form-layout demotion is disabled",
-                        _ => "left unchanged; table classifier returned uncertain",
+                        _ => "classified as non-data table but form-layout demotion is disabled",
                     }));
         }
 
@@ -317,29 +322,105 @@ internal static class PdfTableRoleRemediator
         return new TableInventory(table, rows, headerCellCount, maxColumnCount, hasNestedTable, firstRowSnippet);
     }
 
-    private static int PromoteFirstRowCellsToHeaders(TableInventory inventory, CancellationToken cancellationToken)
+    private static int PromoteHeaderRowCellsToHeaders(TableInventory inventory, CancellationToken cancellationToken)
     {
-        if (inventory.Rows.Count == 0)
+        var headerRowIndex = SelectHeaderRowIndex(inventory);
+        if (headerRowIndex is null)
         {
             return 0;
         }
 
+        var headerRow = inventory.Rows[headerRowIndex.Value];
+        var headerIdsByColumn = new List<string>();
         var promoted = 0;
-        foreach (var cell in inventory.Rows[0].Cells)
+        for (var colIndex = 0; colIndex < headerRow.Cells.Count; colIndex++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            var cell = headerRow.Cells[colIndex];
             if (!RoleTd.Equals(cell.Role))
             {
+                if (RoleTh.Equals(cell.Role))
+                {
+                    headerIdsByColumn.Add(EnsureHeaderId(cell.Element));
+                }
+
                 continue;
             }
 
             cell.Element.Put(PdfName.S, RoleTh);
             EnsureColumnScope(cell.Element);
+            headerIdsByColumn.Add(EnsureHeaderId(cell.Element));
             promoted++;
         }
 
+        AssociateDataCellsWithHeaders(inventory, headerRowIndex.Value, headerIdsByColumn, cancellationToken);
         return promoted;
+    }
+
+    private static int? SelectHeaderRowIndex(TableInventory inventory)
+    {
+        if (inventory.Rows.Count == 0)
+        {
+            return null;
+        }
+
+        for (var rowIndex = 0; rowIndex < inventory.Rows.Count; rowIndex++)
+        {
+            var row = inventory.Rows[rowIndex];
+            if (row.Cells.Count >= inventory.MaxColumnCount && row.Cells.Any(c => !string.IsNullOrWhiteSpace(c.Text)))
+            {
+                return rowIndex;
+            }
+        }
+
+        return inventory.Rows[0].Cells.Count > 0 ? 0 : null;
+    }
+
+    private static string EnsureHeaderId(PdfDictionary headerCell)
+    {
+        var existing = headerCell.GetAsString(StructElemIdKey)?.ToUnicodeString();
+        existing = RemediationHelpers.NormalizeWhitespace(existing ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(existing))
+        {
+            return existing;
+        }
+
+        var id = $"rbl-th-{Guid.NewGuid():N}";
+        headerCell.Put(StructElemIdKey, new PdfString(id));
+        return id;
+    }
+
+    private static void AssociateDataCellsWithHeaders(
+        TableInventory inventory,
+        int headerRowIndex,
+        IReadOnlyList<string> headerIdsByColumn,
+        CancellationToken cancellationToken)
+    {
+        if (headerIdsByColumn.Count == 0)
+        {
+            return;
+        }
+
+        for (var rowIndex = 0; rowIndex < inventory.Rows.Count; rowIndex++)
+        {
+            var row = inventory.Rows[rowIndex];
+            for (var colIndex = 0; colIndex < row.Cells.Count; colIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (rowIndex == headerRowIndex || colIndex >= headerIdsByColumn.Count)
+                {
+                    continue;
+                }
+
+                var cell = row.Cells[colIndex];
+                if (RoleTd.Equals(cell.Role))
+                {
+                    EnsureCellHeaders(cell.Element, [headerIdsByColumn[colIndex]]);
+                }
+            }
+        }
     }
 
     private static void EnsureColumnScope(PdfDictionary cell)
@@ -406,6 +487,83 @@ internal static class PdfTableRoleRemediator
         dict.Put(AttrOwnerKey, AttrOwnerTable);
         dict.Put(AttrScopeKey, AttrScopeColumn);
         return dict;
+    }
+
+    private static void EnsureCellHeaders(PdfDictionary cell, IReadOnlyList<string> headerIds)
+    {
+        var attrsObj = cell.Get(PdfName.A);
+        var attrs = Dereference(attrsObj);
+
+        if (attrs is null)
+        {
+            cell.Put(PdfName.A, CreateHeadersAttributeDict(headerIds));
+            return;
+        }
+
+        if (attrs is PdfDictionary dict)
+        {
+            if (TrySetHeaders(dict, headerIds))
+            {
+                return;
+            }
+
+            var array = new PdfArray();
+            array.Add(dict);
+            array.Add(CreateHeadersAttributeDict(headerIds));
+            cell.Put(PdfName.A, array);
+            return;
+        }
+
+        if (attrs is PdfArray attrArray)
+        {
+            foreach (var item in attrArray)
+            {
+                if (Dereference(item) is PdfDictionary itemDict && TrySetHeaders(itemDict, headerIds))
+                {
+                    return;
+                }
+            }
+
+            attrArray.Add(CreateHeadersAttributeDict(headerIds));
+            return;
+        }
+
+        var fallback = new PdfArray();
+        fallback.Add(attrsObj);
+        fallback.Add(CreateHeadersAttributeDict(headerIds));
+        cell.Put(PdfName.A, fallback);
+    }
+
+    private static bool TrySetHeaders(PdfDictionary dict, IReadOnlyList<string> headerIds)
+    {
+        var owner = dict.GetAsName(AttrOwnerKey);
+        if (owner is not null && !AttrOwnerTable.Equals(owner))
+        {
+            return false;
+        }
+
+        dict.Put(AttrOwnerKey, AttrOwnerTable);
+        dict.Put(AttrHeadersKey, CreateHeaderIdArray(headerIds));
+        return true;
+    }
+
+    private static PdfDictionary CreateHeadersAttributeDict(IReadOnlyList<string> headerIds)
+    {
+        var dict = new PdfDictionary();
+        dict.Put(AttrOwnerKey, AttrOwnerTable);
+        dict.Put(AttrHeadersKey, CreateHeaderIdArray(headerIds));
+        return dict;
+    }
+
+    private static PdfArray CreateHeaderIdArray(IReadOnlyList<string> headerIds)
+    {
+        var array = new PdfArray();
+        foreach (var id in headerIds)
+        {
+            array.Add(new PdfString(id));
+        }
+
+        return array;
     }
 
     private static bool CollectTableRows(

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -78,6 +78,7 @@ internal static class PdfTableRoleRemediator
         IPdfTableClassificationService tableClassificationService,
         string? primaryLanguage,
         bool demoteNoHeaderTables,
+        TimeSpan classificationTimeout,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -131,7 +132,32 @@ internal static class PdfTableRoleRemediator
             }
 
             var request = inventory.ToClassificationRequest(primaryLanguage);
-            var classification = await tableClassificationService.ClassifyAsync(request, cancellationToken);
+            PdfTableClassificationResult classification;
+            try
+            {
+                classification = await ClassifyWithTimeoutAsync(
+                    tableClassificationService,
+                    request,
+                    classificationTimeout,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                results.Add(CreateUnchangedResult(inventory, "left unchanged; table classification timed out"));
+                continue;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                results.Add(CreateUnchangedResult(
+                    inventory,
+                    $"left unchanged; table classification failed: {ex.GetType().Name}"));
+                continue;
+            }
+
             var confidence = Math.Clamp(classification.Confidence, 0, 1);
             var isConfidentDataTable = classification.Kind == PdfTableKind.DataTable
                 && confidence >= MinClassifierConfidence;
@@ -166,6 +192,32 @@ internal static class PdfTableRoleRemediator
         }
 
         return results;
+    }
+
+    private static async Task<PdfTableClassificationResult> ClassifyWithTimeoutAsync(
+        IPdfTableClassificationService tableClassificationService,
+        PdfTableClassificationRequest request,
+        TimeSpan classificationTimeout,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (classificationTimeout <= TimeSpan.Zero)
+        {
+            return await tableClassificationService.ClassifyAsync(request, cancellationToken);
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var classificationTask = tableClassificationService.ClassifyAsync(request, timeoutCts.Token);
+        try
+        {
+            return await classificationTask.WaitAsync(classificationTimeout, cancellationToken);
+        }
+        catch (TimeoutException ex)
+        {
+            timeoutCts.Cancel();
+            throw new OperationCanceledException("Table classification timed out.", ex, timeoutCts.Token);
+        }
     }
 
     private static PdfNoHeaderTableRemediation CreateUnchangedResult(TableInventory inventory, string reason) =>

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -89,7 +89,7 @@ internal static class PdfTableRoleRemediator
             return [];
         }
 
-        if (!demoteNoHeaderTables)
+        if (!demoteNoHeaderTables && !promoteFirstRowHeadersForNoHeaderTables)
         {
             return [];
         }
@@ -189,6 +189,18 @@ internal static class PdfTableRoleRemediator
                                 ? "classified as data table; moved header row into THead and promoted cells to TH"
                                 : "classified as data table but no usable header row was available to promote",
                             classification)));
+                continue;
+            }
+
+            if (!demoteNoHeaderTables)
+            {
+                results.Add(CreateUnchangedResult(
+                    inventory,
+                    BuildClassifierDecisionReason(
+                        classification.Kind == PdfTableKind.DataTable
+                            ? $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; no-header table demotion disabled"
+                            : "classified as non-data table; no-header table demotion disabled",
+                        classification)));
                 continue;
             }
 

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -28,6 +28,7 @@ internal static class PdfTableRoleRemediator
     private const int MaxMarkedContentTraversalDepth = 64;
     private const int MaxMarkedContentTraversalNodes = 4096;
     private const int MaxTableDemotionTraversalNodes = 4096;
+    private const int MaxStructTreeTraversalNodes = 4096;
     private const double MinClassifierConfidence = 0.7;
     private static readonly PdfName RoleTable = new("Table");
     private static readonly PdfName RoleTHead = new("THead");
@@ -476,13 +477,25 @@ internal static class PdfTableRoleRemediator
         CancellationToken cancellationToken)
     {
         var stack = new Stack<PdfDictionary>();
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var nodesVisited = 0;
         stack.Push(root);
 
         while (stack.Count > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (++nodesVisited > MaxStructTreeTraversalNodes)
+            {
+                return null;
+            }
+
             var current = stack.Pop();
+            if (!TryMarkVisited(current, visited))
+            {
+                continue;
+            }
+
             foreach (var child in ListDirectStructElementChildren(current))
             {
                 if (IsSameStructElement(child, target))
@@ -1082,14 +1095,26 @@ internal static class PdfTableRoleRemediator
     {
         var results = new List<PdfDictionary>();
         var stack = new Stack<PdfObject?>();
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var nodesVisited = 0;
         stack.Push(root.Get(PdfName.K));
 
         while (stack.Count > 0)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (++nodesVisited > MaxStructTreeTraversalNodes)
+            {
+                return results;
+            }
+
             var node = stack.Pop();
             if (node is null)
+            {
+                continue;
+            }
+
+            if (!TryMarkVisited(node, visited))
             {
                 continue;
             }
@@ -1137,40 +1162,62 @@ internal static class PdfTableRoleRemediator
         List<PdfDictionary> results,
         CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
+        var stack = new Stack<PdfObject?>();
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var nodesVisited = 0;
+        stack.Push(node);
 
-        var dereferenced = Dereference(node);
-        if (dereferenced is null)
+        while (stack.Count > 0)
         {
-            return;
-        }
+            cancellationToken.ThrowIfCancellationRequested();
 
-        node = dereferenced;
-
-        if (node is PdfArray array)
-        {
-            foreach (var item in array)
+            if (++nodesVisited > MaxStructTreeTraversalNodes)
             {
-                TraverseTagTreeForList(item, role, results, cancellationToken);
+                return;
             }
 
-            return;
-        }
+            var current = stack.Pop();
+            if (current is null)
+            {
+                continue;
+            }
 
-        if (node is not PdfDictionary dict)
-        {
-            return;
-        }
+            if (!TryMarkVisited(current, visited))
+            {
+                continue;
+            }
 
-        if (dict.ContainsKey(PdfName.S) && role.Equals(dict.GetAsName(PdfName.S)))
-        {
-            results.Add(dict);
-        }
+            var dereferenced = Dereference(current);
+            if (dereferenced is null)
+            {
+                continue;
+            }
 
-        var kids = dict.Get(PdfName.K);
-        if (kids is not null)
-        {
-            TraverseTagTreeForList(kids, role, results, cancellationToken);
+            if (dereferenced is PdfArray array)
+            {
+                for (var i = array.Size() - 1; i >= 0; i--)
+                {
+                    stack.Push(array.Get(i));
+                }
+
+                continue;
+            }
+
+            if (dereferenced is not PdfDictionary dict)
+            {
+                continue;
+            }
+
+            if (dict.ContainsKey(PdfName.S) && role.Equals(dict.GetAsName(PdfName.S)))
+            {
+                results.Add(dict);
+            }
+
+            var kids = dict.Get(PdfName.K);
+            if (kids is not null)
+            {
+                stack.Push(kids);
+            }
         }
     }
 

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -169,7 +169,9 @@ internal static class PdfTableRoleRemediator
                 {
                     results.Add(CreateUnchangedResult(
                         inventory,
-                        "classified as data table; first-row header promotion disabled"));
+                        BuildClassifierDecisionReason(
+                            "classified as data table; first-row header promotion disabled",
+                            classification)));
                     continue;
                 }
 
@@ -182,9 +184,11 @@ internal static class PdfTableRoleRemediator
                         inventory.RowCount,
                         inventory.MaxColumnCount,
                         inventory.FirstRowSnippet,
-                        promoted
-                            ? "classified as data table; moved header row into THead and promoted cells to TH"
-                            : "classified as data table but no usable header row was available to promote"));
+                        BuildClassifierDecisionReason(
+                            promoted
+                                ? "classified as data table; moved header row into THead and promoted cells to TH"
+                                : "classified as data table but no usable header row was available to promote",
+                            classification)));
                 continue;
             }
 
@@ -195,12 +199,27 @@ internal static class PdfTableRoleRemediator
                     inventory.RowCount,
                     inventory.MaxColumnCount,
                     inventory.FirstRowSnippet,
-                    classification.Kind == PdfTableKind.DataTable
-                        ? $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; demoted table roles"
-                        : "classified as non-data table; demoted table roles"));
+                    BuildClassifierDecisionReason(
+                        classification.Kind == PdfTableKind.DataTable
+                            ? $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; demoted table roles"
+                            : "classified as non-data table; demoted table roles",
+                        classification)));
         }
 
         return results;
+    }
+
+    private static string BuildClassifierDecisionReason(
+        string decisionReason,
+        PdfTableClassificationResult classification)
+    {
+        var classifierReason = RemediationHelpers.NormalizeWhitespace(classification.Reason);
+        if (string.IsNullOrWhiteSpace(classifierReason))
+        {
+            return decisionReason;
+        }
+
+        return $"{decisionReason}; classifier reason: {classifierReason}";
     }
 
     private static async Task<PdfTableClassificationResult> ClassifyWithTimeoutAsync(

--- a/server.core/Remediate/Table/IPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/IPdfTableClassificationService.cs
@@ -3,8 +3,7 @@ namespace server.core.Remediate.Table;
 public enum PdfTableKind
 {
     DataTable,
-    LayoutOrFormTable,
-    Uncertain,
+    NotDataTable,
 }
 
 public sealed record PdfTableClassificationRequest(

--- a/server.core/Remediate/Table/IPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/IPdfTableClassificationService.cs
@@ -1,0 +1,24 @@
+namespace server.core.Remediate.Table;
+
+public enum PdfTableKind
+{
+    DataTable,
+    LayoutOrFormTable,
+    Uncertain,
+}
+
+public sealed record PdfTableClassificationRequest(
+    int RowCount,
+    int MaxColumnCount,
+    bool HasNestedTable,
+    IReadOnlyList<IReadOnlyList<string>> Rows,
+    string? PrimaryLanguage = null);
+
+public sealed record PdfTableClassificationResult(PdfTableKind Kind, double Confidence, string Reason);
+
+public interface IPdfTableClassificationService
+{
+    Task<PdfTableClassificationResult> ClassifyAsync(
+        PdfTableClassificationRequest request,
+        CancellationToken cancellationToken);
+}

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -143,7 +143,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         text = RemediationHelpers.NormalizeWhitespace(text);
         if (string.IsNullOrWhiteSpace(text))
         {
-            return new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0, "Empty classifier response.");
+            throw new InvalidOperationException("Empty classifier response.");
         }
 
         var start = text.IndexOf('{');
@@ -174,9 +174,9 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
 
             return new PdfTableClassificationResult(kind, confidence, reason);
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            return new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0, "Classifier response was not valid JSON.");
+            throw new InvalidOperationException("Classifier response was not valid JSON.", ex);
         }
     }
 

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -1,0 +1,151 @@
+using System.ClientModel;
+using System.Text;
+using System.Text.Json;
+using OpenAI.Chat;
+
+namespace server.core.Remediate.Table;
+
+public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificationService
+{
+    private const int MaxRowsInPrompt = 8;
+    private const int MaxCellsPerRowInPrompt = 8;
+    private readonly ChatClient _chatClient;
+
+    public OpenAIPdfTableClassificationService(string apiKey, string model)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
+        }
+
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            throw new ArgumentException("OpenAI model is required.", nameof(model));
+        }
+
+        _chatClient = new ChatClient(model: model, apiKey: apiKey);
+    }
+
+    public async Task<PdfTableClassificationResult> ClassifyAsync(
+        PdfTableClassificationRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        List<ChatMessage> messages =
+        [
+            new SystemChatMessage(BuildSystemInstructions()),
+            new UserChatMessage(BuildPrompt(request)),
+        ];
+
+        ClientResult<ChatCompletion> result =
+            await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
+
+        var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
+        return ParseResult(text);
+    }
+
+    private static string BuildSystemInstructions() =>
+        """
+        You classify PDF tag-tree tables for accessibility remediation.
+        Return only a compact JSON object with:
+        - "kind": one of "data_table", "layout_or_form_table", or "uncertain"
+        - "confidence": a number from 0 to 1
+        - "reason": a short plain-text reason
+
+        Classify based on the table's apparent semantic purpose, not on whether every row is filled in.
+        A data table organizes repeated records, choices, measurements, or values by rows and columns.
+        A layout_or_form_table positions labels, instructions, or form fields without conveying tabular relationships.
+        Use "uncertain" when the evidence is weak or both interpretations are plausible.
+        """;
+
+    private static string BuildPrompt(PdfTableClassificationRequest request)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Classify this no-header PDF table.");
+        sb.Append("Rows: ");
+        sb.AppendLine(request.RowCount.ToString());
+        sb.Append("Max columns: ");
+        sb.AppendLine(request.MaxColumnCount.ToString());
+        sb.Append("Nested table: ");
+        sb.AppendLine(request.HasNestedTable ? "yes" : "no");
+
+        var language = RemediationHelpers.NormalizeWhitespace(request.PrimaryLanguage ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            sb.Append("Primary document language: ");
+            sb.AppendLine(language);
+        }
+
+        sb.AppendLine("Cell text sample:");
+        var rowLimit = Math.Min(request.Rows.Count, MaxRowsInPrompt);
+        for (var rowIndex = 0; rowIndex < rowLimit; rowIndex++)
+        {
+            var cells = request.Rows[rowIndex]
+                .Take(MaxCellsPerRowInPrompt)
+                .Select(cell => string.IsNullOrWhiteSpace(cell) ? "[blank]" : cell);
+            sb.Append("Row ");
+            sb.Append(rowIndex + 1);
+            sb.Append(": ");
+            sb.AppendLine(string.Join(" | ", cells));
+        }
+
+        if (request.Rows.Count > MaxRowsInPrompt)
+        {
+            sb.AppendLine($"Only the first {MaxRowsInPrompt} rows are shown.");
+        }
+
+        return sb.ToString();
+    }
+
+    private static PdfTableClassificationResult ParseResult(string text)
+    {
+        text = RemediationHelpers.NormalizeWhitespace(text);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return new PdfTableClassificationResult(PdfTableKind.Uncertain, 0, "Empty classifier response.");
+        }
+
+        var start = text.IndexOf('{');
+        var end = text.LastIndexOf('}');
+        if (start >= 0 && end > start)
+        {
+            text = text[start..(end + 1)];
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            var root = doc.RootElement;
+            var kindText = root.TryGetProperty("kind", out var kindEl) ? kindEl.GetString() : null;
+            var confidence = root.TryGetProperty("confidence", out var confidenceEl)
+                && confidenceEl.TryGetDouble(out var parsedConfidence)
+                    ? parsedConfidence
+                    : 0;
+            var reason = root.TryGetProperty("reason", out var reasonEl) ? reasonEl.GetString() : null;
+
+            var kind = NormalizeKind(kindText);
+            confidence = Math.Clamp(confidence, 0, 1);
+            reason = RemediationHelpers.NormalizeWhitespace(reason ?? string.Empty);
+            if (string.IsNullOrWhiteSpace(reason))
+            {
+                reason = "Classifier returned no reason.";
+            }
+
+            return new PdfTableClassificationResult(kind, confidence, reason);
+        }
+        catch (JsonException)
+        {
+            return new PdfTableClassificationResult(PdfTableKind.Uncertain, 0, "Classifier response was not valid JSON.");
+        }
+    }
+
+    private static PdfTableKind NormalizeKind(string? value) =>
+        RemediationHelpers.NormalizeWhitespace(value ?? string.Empty).ToLowerInvariant() switch
+        {
+            "data_table" or "data table" or "datatable" => PdfTableKind.DataTable,
+            "layout_or_form_table" or "layout or form table" or "layout_table" or "form_table" =>
+                PdfTableKind.LayoutOrFormTable,
+            _ => PdfTableKind.Uncertain,
+        };
+}

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -9,6 +9,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
 {
     private const int MaxRowsInPrompt = 8;
     private const int MaxCellsPerRowInPrompt = 8;
+    private const int MaxCharsPerCellInPrompt = 200;
     private static readonly BinaryData ClassificationSchema = BinaryData.FromBytes(
         """
         {
@@ -109,7 +110,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         {
             var cells = request.Rows[rowIndex]
                 .Take(MaxCellsPerRowInPrompt)
-                .Select(cell => string.IsNullOrWhiteSpace(cell) ? "[blank]" : cell);
+                .Select(FormatPromptCell);
             sb.Append("Row ");
             sb.Append(rowIndex + 1);
             sb.Append(": ");
@@ -122,6 +123,19 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         }
 
         return sb.ToString();
+    }
+
+    private static string FormatPromptCell(string? cell)
+    {
+        var normalized = RemediationHelpers.NormalizeWhitespace(cell ?? string.Empty);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return "[blank]";
+        }
+
+        return normalized.Length <= MaxCharsPerCellInPrompt
+            ? normalized
+            : $"{normalized[..MaxCharsPerCellInPrompt]}...";
     }
 
     private static PdfTableClassificationResult ParseResult(string text)

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -9,6 +9,27 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
 {
     private const int MaxRowsInPrompt = 8;
     private const int MaxCellsPerRowInPrompt = 8;
+    private static readonly BinaryData ClassificationSchema = BinaryData.FromBytes(
+        """
+        {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": ["data_table", "layout_or_form_table", "uncertain"]
+                },
+                "confidence": {
+                    "type": "number"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            },
+            "required": ["kind", "confidence", "reason"],
+            "additionalProperties": false
+        }
+        """u8.ToArray());
+
     private readonly ChatClient _chatClient;
 
     public OpenAIPdfTableClassificationService(string apiKey, string model)
@@ -38,8 +59,16 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
             new UserChatMessage(BuildPrompt(request)),
         ];
 
+        ChatCompletionOptions options = new()
+        {
+            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
+                jsonSchemaFormatName: "pdf_table_classification",
+                jsonSchema: ClassificationSchema,
+                jsonSchemaIsStrict: true),
+        };
+
         ClientResult<ChatCompletion> result =
-            await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
+            await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
 
         var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
         return ParseResult(text);
@@ -48,15 +77,11 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
     private static string BuildSystemInstructions() =>
         """
         You classify PDF tag-tree tables for accessibility remediation.
-        Return only a compact JSON object with:
-        - "kind": one of "data_table", "layout_or_form_table", or "uncertain"
-        - "confidence": a number from 0 to 1
-        - "reason": a short plain-text reason
-
         Classify based on the table's apparent semantic purpose, not on whether every row is filled in.
         A data table organizes repeated records, choices, measurements, or values by rows and columns.
         A layout_or_form_table positions labels, instructions, or form fields without conveying tabular relationships.
         Use "uncertain" when the evidence is weak or both interpretations are plausible.
+        Set confidence from 0 to 1 and keep the reason short.
         """;
 
     private static string BuildPrompt(PdfTableClassificationRequest request)

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -16,7 +16,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
             "properties": {
                 "kind": {
                     "type": "string",
-                    "enum": ["data_table", "layout_or_form_table", "uncertain"]
+                    "enum": ["data_table", "not_data_table"]
                 },
                 "confidence": {
                     "type": "number"
@@ -77,10 +77,11 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
     private static string BuildSystemInstructions() =>
         """
         You classify PDF tag-tree tables for accessibility remediation.
+        Decide whether the table is a semantic data table.
         Classify based on the table's apparent semantic purpose, not on whether every row is filled in.
         A data table organizes repeated records, choices, measurements, or values by rows and columns.
-        A layout_or_form_table positions labels, instructions, or form fields without conveying tabular relationships.
-        Use "uncertain" when the evidence is weak or both interpretations are plausible.
+        Return not_data_table when the table appears to position labels, instructions, or form fields without conveying tabular relationships.
+        Return not_data_table when the evidence is weak or both interpretations are plausible.
         Set confidence from 0 to 1 and keep the reason short.
         """;
 
@@ -128,7 +129,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         text = RemediationHelpers.NormalizeWhitespace(text);
         if (string.IsNullOrWhiteSpace(text))
         {
-            return new PdfTableClassificationResult(PdfTableKind.Uncertain, 0, "Empty classifier response.");
+            return new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0, "Empty classifier response.");
         }
 
         var start = text.IndexOf('{');
@@ -161,7 +162,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         }
         catch (JsonException)
         {
-            return new PdfTableClassificationResult(PdfTableKind.Uncertain, 0, "Classifier response was not valid JSON.");
+            return new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0, "Classifier response was not valid JSON.");
         }
     }
 
@@ -169,8 +170,8 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         RemediationHelpers.NormalizeWhitespace(value ?? string.Empty).ToLowerInvariant() switch
         {
             "data_table" or "data table" or "datatable" => PdfTableKind.DataTable,
-            "layout_or_form_table" or "layout or form table" or "layout_table" or "form_table" =>
-                PdfTableKind.LayoutOrFormTable,
-            _ => PdfTableKind.Uncertain,
+            "not_data_table" or "not data table" or "notdatatable" or "layout_or_form_table" or
+                "layout or form table" or "layout_table" or "form_table" => PdfTableKind.NotDataTable,
+            _ => PdfTableKind.NotDataTable,
         };
 }

--- a/server.core/Remediate/Table/SamplePdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/SamplePdfTableClassificationService.cs
@@ -1,0 +1,13 @@
+namespace server.core.Remediate.Table;
+
+public sealed class SamplePdfTableClassificationService : IPdfTableClassificationService
+{
+    public Task<PdfTableClassificationResult> ClassifyAsync(
+        PdfTableClassificationRequest request,
+        CancellationToken cancellationToken)
+    {
+        _ = request;
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new PdfTableClassificationResult(PdfTableKind.Uncertain, 0, "No classifier configured."));
+    }
+}

--- a/server.core/Remediate/Table/SamplePdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/SamplePdfTableClassificationService.cs
@@ -8,6 +8,6 @@ public sealed class SamplePdfTableClassificationService : IPdfTableClassificatio
     {
         _ = request;
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(new PdfTableClassificationResult(PdfTableKind.Uncertain, 0, "No classifier configured."));
+        return Task.FromResult(new PdfTableClassificationResult(PdfTableKind.DataTable, 1, "Sample classifier preserves table semantics."));
     }
 }

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -1,0 +1,419 @@
+using FluentAssertions;
+using iText.Kernel.Pdf;
+using iText.Layout;
+using iText.Layout.Element;
+using iText.Layout.Properties;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using server.core.Remediate;
+using server.core.Remediate.AltText;
+using server.core.Remediate.Rasterize;
+using server.core.Remediate.Table;
+using server.core.Remediate.Title;
+
+namespace server.tests.Integration.Remediate;
+
+public sealed class PdfRemediationProcessorNoHeaderTableTests
+{
+    private static readonly PdfName RoleTable = new("Table");
+    private static readonly PdfName RoleTh = new("TH");
+    private static readonly PdfName RoleTd = new("TD");
+    private static readonly PdfName AttrOwnerKey = new("O");
+    private static readonly PdfName AttrOwnerTable = new("Table");
+    private static readonly PdfName AttrScopeKey = new("Scope");
+    private static readonly PdfName AttrScopeColumn = new("Column");
+
+    [Fact]
+    public async Task ProcessAsync_NoHeaderDataTable_PromotesFirstRowCellsToColumnHeaders()
+    {
+        await RunPdfTestAsync(
+            "no-header-data-table",
+            CreateNoHeaderServiceDatesTablePdf,
+            new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Looks like a data table."),
+            ]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+
+                var headers = ListStructElementsByRole(outputPdf, RoleTh);
+                headers.Should().HaveCount(3);
+                headers.Should().OnlyContain(header => HasColumnScope(header));
+            });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoHeaderFormLayoutTable_DemotesTableRoles()
+    {
+        await RunPdfTestAsync(
+            "no-header-form-layout-table",
+            CreateNoHeaderContactFormTablePdf,
+            new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.LayoutOrFormTable, 0.95, "Looks like a form layout."),
+            ]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
+            });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_TableAlreadyContainingHeaders_LeavesHeadersUnchanged()
+    {
+        await RunPdfTestAsync(
+            "table-with-existing-headers",
+            CreateTableWithHeadersPdf,
+            new QueuePdfTableClassificationService([]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTh).Should().HaveCount(2);
+            });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_AmbiguousNoHeaderTable_LeavesTableUnchanged()
+    {
+        await RunPdfTestAsync(
+            "ambiguous-no-header-table",
+            CreateAmbiguousNoHeaderTablePdf,
+            new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.Uncertain, 0.95, "Both interpretations are plausible."),
+            ]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTh).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(4);
+            });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_VerificationPdfShape_DemotesFormTableAndPromotesServiceDateHeaders()
+    {
+        await RunPdfTestAsync(
+            "verification-pdf-shape",
+            CreateVerificationPdfShape,
+            new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.LayoutOrFormTable, 0.95, "Top table is a form layout."),
+                new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Service dates are tabular records."),
+            ]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+
+                var headers = ListStructElementsByRole(outputPdf, RoleTh);
+                headers.Should().HaveCount(3);
+                headers.Should().OnlyContain(header => HasColumnScope(header));
+            });
+    }
+
+    private static async Task RunPdfTestAsync(
+        string testName,
+        Action<string> createPdf,
+        QueuePdfTableClassificationService tableClassificationService,
+        Action<PdfDocument> assert)
+    {
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"{testName}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            createPdf(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
+                tableClassificationService,
+                new StablePdfTitleService(),
+                Options.Create(new PdfRemediationOptions()),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: testName,
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            assert(outputPdf);
+            tableClassificationService.AssertAllResponsesConsumed();
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    private static void CreateNoHeaderServiceDatesTablePdf(string path)
+    {
+        using var writer = new PdfWriter(path);
+        using var pdf = new PdfDocument(writer);
+        pdf.SetTagged();
+
+        using var doc = new Document(pdf);
+
+        var table = new Table(UnitValue.CreatePercentArray([1f, 1f, 1f])).UseAllAvailableWidth();
+        table.AddCell(new Cell().Add(new Paragraph("From / To")));
+        table.AddCell(new Cell().Add(new Paragraph("Department")));
+        table.AddCell(new Cell().Add(new Paragraph("Status (Staff, Academic)")));
+        table.AddCell(new Cell().Add(new Paragraph("Jan 2024 - Feb 2024")));
+        table.AddCell(new Cell().Add(new Paragraph("Human Resources")));
+        table.AddCell(new Cell().Add(new Paragraph("Staff")));
+        table.AddCell(new Cell().Add(new Paragraph("Mar 2024 - Apr 2024")));
+        table.AddCell(new Cell().Add(new Paragraph("Finance")));
+        table.AddCell(new Cell().Add(new Paragraph("Academic")));
+        doc.Add(table);
+    }
+
+    private static void CreateNoHeaderContactFormTablePdf(string path)
+    {
+        using var writer = new PdfWriter(path);
+        using var pdf = new PdfDocument(writer);
+        pdf.SetTagged();
+
+        using var doc = new Document(pdf);
+        AddContactFormTable(doc);
+    }
+
+    private static void CreateTableWithHeadersPdf(string path)
+    {
+        using var writer = new PdfWriter(path);
+        using var pdf = new PdfDocument(writer);
+        pdf.SetTagged();
+
+        using var doc = new Document(pdf);
+
+        var table = new Table(UnitValue.CreatePercentArray([1f, 1f])).UseAllAvailableWidth();
+        var nameHeader = new Cell().Add(new Paragraph("Name"));
+        nameHeader.GetAccessibilityProperties().SetRole("TH");
+        var amountHeader = new Cell().Add(new Paragraph("Amount"));
+        amountHeader.GetAccessibilityProperties().SetRole("TH");
+        table.AddCell(nameHeader);
+        table.AddCell(amountHeader);
+        table.AddCell(new Cell().Add(new Paragraph("Alice")));
+        table.AddCell(new Cell().Add(new Paragraph("$10")));
+        doc.Add(table);
+    }
+
+    private static void CreateAmbiguousNoHeaderTablePdf(string path)
+    {
+        using var writer = new PdfWriter(path);
+        using var pdf = new PdfDocument(writer);
+        pdf.SetTagged();
+
+        using var doc = new Document(pdf);
+
+        var table = new Table(UnitValue.CreatePercentArray([1f, 1f])).UseAllAvailableWidth();
+        table.AddCell(new Cell().Add(new Paragraph("Alpha")));
+        table.AddCell(new Cell().Add(new Paragraph("Beta")));
+        table.AddCell(new Cell().Add(new Paragraph("Gamma")));
+        table.AddCell(new Cell().Add(new Paragraph("Delta")));
+        doc.Add(table);
+    }
+
+    private static void CreateVerificationPdfShape(string path)
+    {
+        using var writer = new PdfWriter(path);
+        using var pdf = new PdfDocument(writer);
+        pdf.SetTagged();
+
+        using var doc = new Document(pdf);
+
+        AddContactFormTable(doc);
+        doc.Add(new Paragraph("Service Dates"));
+        AddServiceDatesFormTable(doc);
+    }
+
+    private static void AddContactFormTable(Document doc)
+    {
+        var table = new Table(UnitValue.CreatePercentArray([1f, 1f])).UseAllAvailableWidth();
+        table.AddCell(new Cell().Add(new Paragraph("TO BE COMPLETED BY EMPLOYEE")));
+        table.AddCell(new Cell().Add(new Paragraph("Contact information for PREVIOUS employer")));
+        table.AddCell(new Cell().Add(new Paragraph("Payroll processor in CURRENT UCD Department")));
+        table.AddCell(new Cell().Add(new Paragraph("Attention / Name")));
+        table.AddCell(new Cell().Add(new Paragraph("Employer / Dept")));
+        table.AddCell(new Cell().Add(new Paragraph("Address / Address")));
+        table.AddCell(new Cell().Add(new Paragraph("Phone")));
+        table.AddCell(new Cell().Add(new Paragraph("Email")));
+        table.AddCell(new Cell().Add(new Paragraph("Signature")));
+        table.AddCell(new Cell().Add(new Paragraph("Date")));
+        doc.Add(table);
+    }
+
+    private static void AddServiceDatesFormTable(Document doc)
+    {
+        var table = new Table(UnitValue.CreatePercentArray([1f, 1f, 1f])).UseAllAvailableWidth();
+        table.AddCell(new Cell().Add(new Paragraph("From / To")));
+        table.AddCell(new Cell().Add(new Paragraph("Department")));
+        table.AddCell(new Cell().Add(new Paragraph("Status (Staff, Academic)")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        table.AddCell(new Cell().Add(new Paragraph("")));
+        doc.Add(table);
+    }
+
+    private static bool HasColumnScope(PdfDictionary structElem)
+    {
+        var attrs = Dereference(structElem.Get(PdfName.A));
+        if (attrs is PdfDictionary dict)
+        {
+            return HasColumnScopeAttribute(dict);
+        }
+
+        if (attrs is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                if (Dereference(item) is PdfDictionary itemDict && HasColumnScopeAttribute(itemDict))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasColumnScopeAttribute(PdfDictionary dict)
+    {
+        var owner = dict.GetAsName(AttrOwnerKey);
+        var scope = dict.GetAsName(AttrScopeKey);
+        return AttrOwnerTable.Equals(owner) && AttrScopeColumn.Equals(scope);
+    }
+
+    private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
+    {
+        var results = new List<PdfDictionary>();
+
+        var catalogDict = pdf.GetCatalog().GetPdfObject();
+        var structTreeRootDict = catalogDict.GetAsDictionary(PdfName.StructTreeRoot);
+        if (structTreeRootDict is null)
+        {
+            return results;
+        }
+
+        var rootKids = structTreeRootDict.Get(PdfName.K);
+        if (rootKids is null)
+        {
+            return results;
+        }
+
+        Traverse(rootKids, role, results);
+        return results;
+    }
+
+    private static void Traverse(PdfObject node, PdfName role, List<PdfDictionary> results)
+    {
+        var dereferenced = Dereference(node);
+        if (dereferenced is null)
+        {
+            return;
+        }
+
+        node = dereferenced;
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                Traverse(item, role, results);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        var s = dict.GetAsName(PdfName.S);
+        if (role.Equals(s))
+        {
+            results.Add(dict);
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            Traverse(kids, role, results);
+        }
+    }
+
+    private static PdfObject? Dereference(PdfObject? obj)
+    {
+        if (obj is null)
+        {
+            return null;
+        }
+
+        if (obj is PdfIndirectReference reference)
+        {
+            return reference.GetRefersTo(true);
+        }
+
+        return obj;
+    }
+
+    private sealed class ThrowingAltTextService : IAltTextService
+    {
+        public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Alt text service should not be called for no-header table tests.");
+
+        public Task<string> GetAltTextForLinkAsync(LinkAltTextRequest request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Alt text service should not be called for no-header table tests.");
+
+        public string GetFallbackAltTextForImage() => "fake image alt text";
+
+        public string GetFallbackAltTextForLink() => "fake link alt text";
+    }
+
+    private sealed class QueuePdfTableClassificationService : IPdfTableClassificationService
+    {
+        private readonly Queue<PdfTableClassificationResult> _responses;
+
+        public QueuePdfTableClassificationService(IEnumerable<PdfTableClassificationResult> responses)
+        {
+            _responses = new Queue<PdfTableClassificationResult>(responses);
+        }
+
+        public Task<PdfTableClassificationResult> ClassifyAsync(
+            PdfTableClassificationRequest request,
+            CancellationToken cancellationToken)
+        {
+            request.RowCount.Should().BeGreaterThanOrEqualTo(2);
+            request.MaxColumnCount.Should().BeGreaterThanOrEqualTo(2);
+            request.Rows.Should().NotBeEmpty();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException("Table classifier was called more times than expected.");
+            }
+
+            return Task.FromResult(_responses.Dequeue());
+        }
+
+        public void AssertAllResponsesConsumed() => _responses.Should().BeEmpty();
+    }
+
+    private sealed class StablePdfTitleService : IPdfTitleService
+    {
+        public Task<string> GenerateTitleAsync(PdfTitleRequest request, CancellationToken cancellationToken) =>
+            Task.FromResult("Generated test document title");
+    }
+}

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -16,17 +16,13 @@ namespace server.tests.Integration.Remediate;
 public sealed class PdfRemediationProcessorNoHeaderTableTests
 {
     private static readonly PdfName RoleTable = new("Table");
+    private static readonly PdfName RoleTHead = new("THead");
+    private static readonly PdfName RoleTBody = new("TBody");
+    private static readonly PdfName RoleTr = new("TR");
     private static readonly PdfName RoleTh = new("TH");
     private static readonly PdfName RoleTd = new("TD");
-    private static readonly PdfName AttrOwnerKey = new("O");
-    private static readonly PdfName AttrOwnerTable = new("Table");
-    private static readonly PdfName AttrScopeKey = new("Scope");
-    private static readonly PdfName AttrScopeColumn = new("Column");
-    private static readonly PdfName AttrHeadersKey = new("Headers");
-    private static readonly PdfName StructElemIdKey = new("ID");
-
     [Fact]
-    public async Task ProcessAsync_NoHeaderDataTable_PromotesFirstRowCellsToColumnHeaders()
+    public async Task ProcessAsync_NoHeaderDataTable_MovesFirstRowIntoTableHead()
     {
         await RunPdfTestAsync(
             "no-header-data-table",
@@ -37,14 +33,11 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             outputPdf =>
             {
                 ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
-
-                var headers = ListStructElementsByRole(outputPdf, RoleTh);
-                headers.Should().HaveCount(3);
-                headers.Should().OnlyContain(header => HasColumnScope(header));
-                headers.Should().OnlyContain(header => !string.IsNullOrWhiteSpace(GetHeaderId(header)));
-                ListStructElementsByRole(outputPdf, RoleTd)
-                    .Should()
-                    .OnlyContain(cell => HasHeaderReference(cell));
+                ListStructElementsByRole(outputPdf, RoleTHead).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTBody).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTr).Should().HaveCount(3);
+                ListStructElementsByRole(outputPdf, RoleTh).Should().HaveCount(3);
+                ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(6);
             });
     }
 
@@ -113,7 +106,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     }
 
     [Fact]
-    public async Task ProcessAsync_VerificationPdfShape_DemotesFormTableAndPromotesServiceDateHeaders()
+    public async Task ProcessAsync_VerificationPdfShape_DemotesFormTableAndAddsDataTableHeader()
     {
         await RunPdfTestAsync(
             "verification-pdf-shape",
@@ -125,14 +118,11 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             outputPdf =>
             {
                 ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
-
-                var headers = ListStructElementsByRole(outputPdf, RoleTh);
-                headers.Should().HaveCount(3);
-                headers.Should().OnlyContain(header => HasColumnScope(header));
-                headers.Should().OnlyContain(header => !string.IsNullOrWhiteSpace(GetHeaderId(header)));
-                ListStructElementsByRole(outputPdf, RoleTd)
-                    .Should()
-                    .OnlyContain(cell => HasHeaderReference(cell));
+                ListStructElementsByRole(outputPdf, RoleTHead).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTBody).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTr).Should().HaveCount(4);
+                ListStructElementsByRole(outputPdf, RoleTh).Should().HaveCount(3);
+                ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(9);
             });
     }
 
@@ -291,72 +281,6 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         table.AddCell(new Cell().Add(new Paragraph("")));
         table.AddCell(new Cell().Add(new Paragraph("")));
         doc.Add(table);
-    }
-
-    private static bool HasColumnScope(PdfDictionary structElem)
-    {
-        var attrs = Dereference(structElem.Get(PdfName.A));
-        if (attrs is PdfDictionary dict)
-        {
-            return HasColumnScopeAttribute(dict);
-        }
-
-        if (attrs is PdfArray array)
-        {
-            foreach (var item in array)
-            {
-                if (Dereference(item) is PdfDictionary itemDict && HasColumnScopeAttribute(itemDict))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static bool HasColumnScopeAttribute(PdfDictionary dict)
-    {
-        var owner = dict.GetAsName(AttrOwnerKey);
-        var scope = dict.GetAsName(AttrScopeKey);
-        return AttrOwnerTable.Equals(owner) && AttrScopeColumn.Equals(scope);
-    }
-
-    private static string? GetHeaderId(PdfDictionary structElem) =>
-        structElem.GetAsString(StructElemIdKey)?.ToUnicodeString();
-
-    private static bool HasHeaderReference(PdfDictionary structElem)
-    {
-        var attrs = Dereference(structElem.Get(PdfName.A));
-        if (attrs is PdfDictionary dict)
-        {
-            return HasHeaderReferenceAttribute(dict);
-        }
-
-        if (attrs is PdfArray array)
-        {
-            foreach (var item in array)
-            {
-                if (Dereference(item) is PdfDictionary itemDict && HasHeaderReferenceAttribute(itemDict))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static bool HasHeaderReferenceAttribute(PdfDictionary dict)
-    {
-        var owner = dict.GetAsName(AttrOwnerKey);
-        if (!AttrOwnerTable.Equals(owner))
-        {
-            return false;
-        }
-
-        var headers = Dereference(dict.Get(AttrHeadersKey));
-        return headers is PdfArray array && array.Size() > 0;
     }
 
     private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -3,6 +3,7 @@ using iText.Kernel.Pdf;
 using iText.Layout;
 using iText.Layout.Element;
 using iText.Layout.Properties;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using server.core.Remediate;
@@ -42,6 +43,12 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
                 ListStructElementsByRole(outputPdf, RoleTh).Should().HaveCount(3);
                 ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(6);
                 AssertPromotedHeaderStructure(outputPdf);
+            },
+            logs =>
+            {
+                logs.Should().Contain(message =>
+                    message.Contains("moved header row into THead", StringComparison.Ordinal)
+                    && message.Contains("classifier reason: Looks like a data table.", StringComparison.Ordinal));
             });
 
         tableClassificationService.Requests.Should().ContainSingle();
@@ -122,6 +129,12 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             {
                 ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
                 ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
+            },
+            logs =>
+            {
+                logs.Should().Contain(message =>
+                    message.Contains("classified as non-data table", StringComparison.Ordinal)
+                    && message.Contains("classifier reason: Does not look like a data table.", StringComparison.Ordinal));
             });
     }
 
@@ -318,7 +331,8 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         string testName,
         Action<string> createPdf,
         QueuePdfTableClassificationService tableClassificationService,
-        Action<PdfDocument> assert)
+        Action<PdfDocument> assert,
+        Action<IReadOnlyList<string>>? assertLogs = null)
     {
         var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"{testName}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(runRoot);
@@ -329,6 +343,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             createPdf(inputPdfPath);
 
             var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var logger = new CapturingLogger<PdfRemediationProcessor>();
             var sut = new PdfRemediationProcessor(
                 new ThrowingAltTextService(),
                 new NoopPdfBookmarkService(),
@@ -336,7 +351,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
                 tableClassificationService,
                 new StablePdfTitleService(),
                 Options.Create(new PdfRemediationOptions()),
-                NullLogger<PdfRemediationProcessor>.Instance);
+                logger);
 
             await sut.ProcessAsync(
                 fileId: testName,
@@ -346,6 +361,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
 
             using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
             assert(outputPdf);
+            assertLogs?.Invoke(logger.Messages);
             tableClassificationService.AssertAllResponsesConsumed();
         }
         finally
@@ -775,6 +791,29 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         {
             CallCount++;
             return new TaskCompletionSource<PdfTableClassificationResult>().Task;
+        }
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        private readonly List<string> _messages = [];
+
+        public IReadOnlyList<string> Messages => _messages;
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull =>
+            NullLogger.Instance.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Add(formatter(state, exception));
         }
     }
 

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -47,8 +47,12 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             logs =>
             {
                 logs.Should().Contain(message =>
-                    message.Contains("moved header row into THead", StringComparison.Ordinal)
-                    && message.Contains("classifier reason: Looks like a data table.", StringComparison.Ordinal));
+                    message.Contains("No-header table remediation decision", StringComparison.Ordinal)
+                    && message.Contains("action=PromotedHeaderRow", StringComparison.Ordinal)
+                    && message.Contains("rows=3", StringComparison.Ordinal)
+                    && message.Contains("columns=3", StringComparison.Ordinal));
+                logs.Should().NotContain(message =>
+                    message.Contains("Looks like a data table.", StringComparison.Ordinal));
             });
 
         tableClassificationService.Requests.Should().ContainSingle();
@@ -133,8 +137,10 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             logs =>
             {
                 logs.Should().Contain(message =>
-                    message.Contains("classified as non-data table", StringComparison.Ordinal)
-                    && message.Contains("classifier reason: Does not look like a data table.", StringComparison.Ordinal));
+                    message.Contains("No-header table remediation decision", StringComparison.Ordinal)
+                    && message.Contains("action=DemotedNoHeaderTable", StringComparison.Ordinal));
+                logs.Should().NotContain(message =>
+                    message.Contains("Does not look like a data table.", StringComparison.Ordinal));
             });
     }
 
@@ -153,7 +159,9 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             CreateNoHeaderContactFormTablePdf(inputPdfPath);
 
             var outputPdfPath = Path.Combine(runRoot, "output.pdf");
-            var tableClassificationService = new QueuePdfTableClassificationService([]);
+            var tableClassificationService = new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0.95, "Does not look like a data table."),
+            ]);
             var sut = new PdfRemediationProcessor(
                 new ThrowingAltTextService(),
                 new NoopPdfBookmarkService(),
@@ -177,7 +185,62 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             ListStructElementsByRole(outputPdf, RoleTr).Should().HaveCount(5);
             ListStructElementsByRole(outputPdf, RoleTh).Should().BeEmpty();
             ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(10);
-            tableClassificationService.Requests.Should().BeEmpty();
+            tableClassificationService.Requests.Should().ContainSingle();
+            tableClassificationService.Requests[0].RowCount.Should().Be(5);
+            tableClassificationService.AssertAllResponsesConsumed();
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenDemoteNoHeaderTablesDisabled_StillPromotesNoHeaderDataTable()
+    {
+        var runRoot = Path.Combine(
+            Path.GetTempPath(),
+            "readable-tests",
+            $"no-header-demotion-disabled-promotes-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateNoHeaderServiceDatesTablePdf(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var tableClassificationService = new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Looks like a data table."),
+            ]);
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
+                tableClassificationService,
+                new StablePdfTitleService(),
+                Options.Create(new PdfRemediationOptions
+                {
+                    DemoteNoHeaderTables = false,
+                }),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "no-header-demotion-disabled-promotes",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+            ListStructElementsByRole(outputPdf, RoleTHead).Should().HaveCount(1);
+            ListStructElementsByRole(outputPdf, RoleTBody).Should().HaveCount(1);
+            ListStructElementsByRole(outputPdf, RoleTh).Should().HaveCount(3);
+            ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(6);
+            tableClassificationService.Requests.Should().ContainSingle();
             tableClassificationService.AssertAllResponsesConsumed();
         }
         finally

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -22,6 +22,8 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     private static readonly PdfName AttrOwnerTable = new("Table");
     private static readonly PdfName AttrScopeKey = new("Scope");
     private static readonly PdfName AttrScopeColumn = new("Column");
+    private static readonly PdfName AttrHeadersKey = new("Headers");
+    private static readonly PdfName StructElemIdKey = new("ID");
 
     [Fact]
     public async Task ProcessAsync_NoHeaderDataTable_PromotesFirstRowCellsToColumnHeaders()
@@ -39,6 +41,10 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
                 var headers = ListStructElementsByRole(outputPdf, RoleTh);
                 headers.Should().HaveCount(3);
                 headers.Should().OnlyContain(header => HasColumnScope(header));
+                headers.Should().OnlyContain(header => !string.IsNullOrWhiteSpace(GetHeaderId(header)));
+                ListStructElementsByRole(outputPdf, RoleTd)
+                    .Should()
+                    .OnlyContain(cell => HasHeaderReference(cell));
             });
     }
 
@@ -49,7 +55,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             "no-header-form-layout-table",
             CreateNoHeaderContactFormTablePdf,
             new QueuePdfTableClassificationService([
-                new PdfTableClassificationResult(PdfTableKind.LayoutOrFormTable, 0.95, "Looks like a form layout."),
+                new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0.95, "Does not look like a data table."),
             ]),
             outputPdf =>
             {
@@ -73,19 +79,36 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     }
 
     [Fact]
-    public async Task ProcessAsync_AmbiguousNoHeaderTable_LeavesTableUnchanged()
+    public async Task ProcessAsync_AmbiguousNoHeaderTable_DefaultsToNonDataAndDemotesTable()
     {
         await RunPdfTestAsync(
             "ambiguous-no-header-table",
             CreateAmbiguousNoHeaderTablePdf,
             new QueuePdfTableClassificationService([
-                new PdfTableClassificationResult(PdfTableKind.Uncertain, 0.95, "Both interpretations are plausible."),
+                new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0.3, "Low confidence that this is a data table."),
             ]),
             outputPdf =>
             {
-                ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+                ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
                 ListStructElementsByRole(outputPdf, RoleTh).Should().BeEmpty();
-                ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(4);
+                ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
+            });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_LowConfidenceDataTable_DefaultsToNonDataAndDemotesTable()
+    {
+        await RunPdfTestAsync(
+            "low-confidence-data-table",
+            CreateNoHeaderServiceDatesTablePdf,
+            new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.DataTable, 0.4, "Possibly data, but confidence is low."),
+            ]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTh).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
             });
     }
 
@@ -96,7 +119,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             "verification-pdf-shape",
             CreateVerificationPdfShape,
             new QueuePdfTableClassificationService([
-                new PdfTableClassificationResult(PdfTableKind.LayoutOrFormTable, 0.95, "Top table is a form layout."),
+                new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0.95, "Top table is not a data table."),
                 new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Service dates are tabular records."),
             ]),
             outputPdf =>
@@ -106,6 +129,10 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
                 var headers = ListStructElementsByRole(outputPdf, RoleTh);
                 headers.Should().HaveCount(3);
                 headers.Should().OnlyContain(header => HasColumnScope(header));
+                headers.Should().OnlyContain(header => !string.IsNullOrWhiteSpace(GetHeaderId(header)));
+                ListStructElementsByRole(outputPdf, RoleTd)
+                    .Should()
+                    .OnlyContain(cell => HasHeaderReference(cell));
             });
     }
 
@@ -293,6 +320,43 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         var owner = dict.GetAsName(AttrOwnerKey);
         var scope = dict.GetAsName(AttrScopeKey);
         return AttrOwnerTable.Equals(owner) && AttrScopeColumn.Equals(scope);
+    }
+
+    private static string? GetHeaderId(PdfDictionary structElem) =>
+        structElem.GetAsString(StructElemIdKey)?.ToUnicodeString();
+
+    private static bool HasHeaderReference(PdfDictionary structElem)
+    {
+        var attrs = Dereference(structElem.Get(PdfName.A));
+        if (attrs is PdfDictionary dict)
+        {
+            return HasHeaderReferenceAttribute(dict);
+        }
+
+        if (attrs is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                if (Dereference(item) is PdfDictionary itemDict && HasHeaderReferenceAttribute(itemDict))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasHeaderReferenceAttribute(PdfDictionary dict)
+    {
+        var owner = dict.GetAsName(AttrOwnerKey);
+        if (!AttrOwnerTable.Equals(owner))
+        {
+            return false;
+        }
+
+        var headers = Dereference(dict.Get(AttrHeadersKey));
+        return headers is PdfArray array && array.Size() > 0;
     }
 
     private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -127,6 +127,55 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     }
 
     [Fact]
+    public async Task ProcessAsync_NoHeaderTableClassificationTimeout_LeavesTableUnchanged()
+    {
+        var runRoot = Path.Combine(
+            Path.GetTempPath(),
+            "readable-tests",
+            $"no-header-classification-timeout-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateNoHeaderContactFormTablePdf(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var tableClassificationService = new NeverCompletingPdfTableClassificationService();
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
+                tableClassificationService,
+                new StablePdfTitleService(),
+                Options.Create(new PdfRemediationOptions
+                {
+                    NoHeaderTableClassificationTimeoutSeconds = 1,
+                }),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "no-header-classification-timeout",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            tableClassificationService.CallCount.Should().Be(1);
+            ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+            ListStructElementsByRole(outputPdf, RoleTr).Should().NotBeEmpty();
+            ListStructElementsByRole(outputPdf, RoleTd).Should().NotBeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ProcessAsync_VerificationPdfShape_DemotesFormTableAndAddsDataTableHeader()
     {
         await RunPdfTestAsync(
@@ -503,6 +552,19 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         }
 
         public void AssertAllResponsesConsumed() => _responses.Should().BeEmpty();
+    }
+
+    private sealed class NeverCompletingPdfTableClassificationService : IPdfTableClassificationService
+    {
+        public int CallCount { get; private set; }
+
+        public Task<PdfTableClassificationResult> ClassifyAsync(
+            PdfTableClassificationRequest request,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return new TaskCompletionSource<PdfTableClassificationResult>().Task;
+        }
     }
 
     private sealed class StablePdfTitleService : IPdfTitleService

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -25,12 +25,14 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     [Fact]
     public async Task ProcessAsync_NoHeaderDataTable_MovesFirstRowIntoTableHead()
     {
+        var tableClassificationService = new QueuePdfTableClassificationService([
+            new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Looks like a data table."),
+        ]);
+
         await RunPdfTestAsync(
             "no-header-data-table",
             CreateNoHeaderServiceDatesTablePdf,
-            new QueuePdfTableClassificationService([
-                new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Looks like a data table."),
-            ]),
+            tableClassificationService,
             outputPdf =>
             {
                 ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
@@ -39,7 +41,18 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
                 ListStructElementsByRole(outputPdf, RoleTr).Should().HaveCount(3);
                 ListStructElementsByRole(outputPdf, RoleTh).Should().HaveCount(3);
                 ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(6);
+                AssertPromotedHeaderStructure(outputPdf);
             });
+
+        tableClassificationService.Requests.Should().ContainSingle();
+        var request = tableClassificationService.Requests.Single();
+        request.RowCount.Should().Be(3);
+        request.MaxColumnCount.Should().Be(3);
+        request.HasNestedTable.Should().BeFalse();
+        request.Rows.Should().HaveCount(3);
+        request.Rows[0].Should().Equal("From / To", "Department", "Status (Staff, Academic)");
+        request.Rows[1].Should().Equal("Jan 2024 - Feb 2024", "Human Resources", "Staff");
+        request.Rows[2].Should().Equal("Mar 2024 - Apr 2024", "Finance", "Academic");
     }
 
     [Fact]
@@ -110,6 +123,57 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
                 ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
                 ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
             });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenDemoteNoHeaderTablesDisabled_LeavesEligibleNoHeaderTableUnchanged()
+    {
+        var runRoot = Path.Combine(
+            Path.GetTempPath(),
+            "readable-tests",
+            $"no-header-demotion-disabled-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateNoHeaderContactFormTablePdf(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var tableClassificationService = new QueuePdfTableClassificationService([]);
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
+                tableClassificationService,
+                new StablePdfTitleService(),
+                Options.Create(new PdfRemediationOptions
+                {
+                    DemoteNoHeaderTables = false,
+                }),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "no-header-demotion-disabled",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+            ListStructElementsByRole(outputPdf, RoleTr).Should().HaveCount(5);
+            ListStructElementsByRole(outputPdf, RoleTh).Should().BeEmpty();
+            ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(10);
+            tableClassificationService.Requests.Should().BeEmpty();
+            tableClassificationService.AssertAllResponsesConsumed();
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
     }
 
     [Fact]
@@ -492,6 +556,37 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         section.Put(PdfName.K, kids);
     }
 
+    private static void AssertPromotedHeaderStructure(PdfDocument pdf)
+    {
+        var table = ListStructElementsByRole(pdf, RoleTable).Single();
+        var tableChildren = ListDirectStructElementChildren(table);
+        tableChildren.Select(c => c.GetAsName(PdfName.S)).Should().Equal(RoleTHead, RoleTBody);
+
+        var thead = tableChildren[0];
+        var tbody = tableChildren[1];
+        IsSameStructElement(thead.Get(PdfName.P), table).Should().BeTrue();
+        IsSameStructElement(tbody.Get(PdfName.P), table).Should().BeTrue();
+
+        var headerRows = ListDirectStructElementChildren(thead);
+        headerRows.Should().ContainSingle();
+        IsSameStructElement(headerRows[0].Get(PdfName.P), thead).Should().BeTrue();
+        ListDirectStructElementChildren(headerRows[0])
+            .Select(c => c.GetAsName(PdfName.S))
+            .Should()
+            .Equal(RoleTh, RoleTh, RoleTh);
+
+        var bodyRows = ListDirectStructElementChildren(tbody);
+        bodyRows.Should().HaveCount(2);
+        bodyRows.Should().OnlyContain(row => IsSameStructElement(row.Get(PdfName.P), tbody));
+        foreach (var row in bodyRows)
+        {
+            ListDirectStructElementChildren(row)
+                .Select(c => c.GetAsName(PdfName.S))
+                .Should()
+                .Equal(RoleTd, RoleTd, RoleTd);
+        }
+    }
+
     private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
     {
         var results = new List<PdfDictionary>();
@@ -511,6 +606,64 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
 
         Traverse(rootKids, role, results);
         return results;
+    }
+
+    private static List<PdfDictionary> ListDirectStructElementChildren(PdfDictionary structElem)
+    {
+        var kids = structElem.Get(PdfName.K);
+        if (kids is null)
+        {
+            return [];
+        }
+
+        var dereferenced = Dereference(kids);
+        if (dereferenced is PdfDictionary kidDict)
+        {
+            return kidDict.ContainsKey(PdfName.S) ? [kidDict] : [];
+        }
+
+        if (dereferenced is not PdfArray array)
+        {
+            return [];
+        }
+
+        var results = new List<PdfDictionary>(array.Size());
+        foreach (var item in array)
+        {
+            if (Dereference(item) is PdfDictionary itemDict && itemDict.ContainsKey(PdfName.S))
+            {
+                results.Add(itemDict);
+            }
+        }
+
+        return results;
+    }
+
+    private static bool IsSameStructElement(PdfObject? candidate, PdfDictionary target)
+    {
+        var targetRef = target.GetIndirectReference();
+        if (targetRef is not null && candidate is PdfIndirectReference candidateRef)
+        {
+            return candidateRef.GetObjNumber() == targetRef.GetObjNumber()
+                && candidateRef.GetGenNumber() == targetRef.GetGenNumber();
+        }
+
+        var candidateDict = Dereference(candidate) as PdfDictionary;
+        if (candidateDict is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(candidateDict, target))
+        {
+            return true;
+        }
+
+        var candidateRefFromDict = candidateDict.GetIndirectReference();
+        return targetRef is not null
+            && candidateRefFromDict is not null
+            && candidateRefFromDict.GetObjNumber() == targetRef.GetObjNumber()
+            && candidateRefFromDict.GetGenNumber() == targetRef.GetGenNumber();
     }
 
     private static void Traverse(PdfObject node, PdfName role, List<PdfDictionary> results)
@@ -582,11 +735,14 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     private sealed class QueuePdfTableClassificationService : IPdfTableClassificationService
     {
         private readonly Queue<PdfTableClassificationResult> _responses;
+        private readonly List<PdfTableClassificationRequest> _requests = [];
 
         public QueuePdfTableClassificationService(IEnumerable<PdfTableClassificationResult> responses)
         {
             _responses = new Queue<PdfTableClassificationResult>(responses);
         }
+
+        public IReadOnlyList<PdfTableClassificationRequest> Requests => _requests;
 
         public Task<PdfTableClassificationResult> ClassifyAsync(
             PdfTableClassificationRequest request,
@@ -596,6 +752,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             request.MaxColumnCount.Should().BeGreaterThanOrEqualTo(2);
             request.Rows.Should().NotBeEmpty();
             cancellationToken.ThrowIfCancellationRequested();
+            _requests.Add(request);
 
             if (_responses.Count == 0)
             {

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -18,6 +18,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     private static readonly PdfName RoleTable = new("Table");
     private static readonly PdfName RoleTHead = new("THead");
     private static readonly PdfName RoleTBody = new("TBody");
+    private static readonly PdfName RoleTFoot = new("TFoot");
     private static readonly PdfName RoleTr = new("TR");
     private static readonly PdfName RoleTh = new("TH");
     private static readonly PdfName RoleTd = new("TD");
@@ -53,6 +54,26 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             outputPdf =>
             {
                 ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
+            });
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoHeaderSectionedFormLayoutTable_DemotesTableSectionRoles()
+    {
+        await RunPdfTestAsync(
+            "no-header-sectioned-form-layout-table",
+            CreateSectionedNoHeaderContactFormTablePdf,
+            new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.NotDataTable, 0.95, "Does not look like a data table."),
+            ]),
+            outputPdf =>
+            {
+                ListStructElementsByRole(outputPdf, RoleTable).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTHead).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTBody).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTFoot).Should().BeEmpty();
+                ListStructElementsByRole(outputPdf, RoleTr).Should().BeEmpty();
                 ListStructElementsByRole(outputPdf, RoleTd).Should().BeEmpty();
             });
     }
@@ -200,6 +221,28 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         AddContactFormTable(doc);
     }
 
+    private static void CreateSectionedNoHeaderContactFormTablePdf(string path)
+    {
+        var basePath = Path.Combine(
+            Path.GetDirectoryName(path) ?? Path.GetTempPath(),
+            $"{Path.GetFileNameWithoutExtension(path)}.base.pdf");
+
+        try
+        {
+            CreateNoHeaderContactFormTablePdf(basePath);
+
+            using var pdf = new PdfDocument(new PdfReader(basePath), new PdfWriter(path));
+            WrapFirstTableRowsInSections(pdf);
+        }
+        finally
+        {
+            if (File.Exists(basePath))
+            {
+                File.Delete(basePath);
+            }
+        }
+    }
+
     private static void CreateTableWithHeadersPdf(string path)
     {
         using var writer = new PdfWriter(path);
@@ -281,6 +324,69 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         table.AddCell(new Cell().Add(new Paragraph("")));
         table.AddCell(new Cell().Add(new Paragraph("")));
         doc.Add(table);
+    }
+
+    private static void WrapFirstTableRowsInSections(PdfDocument pdf)
+    {
+        var table = ListStructElementsByRole(pdf, RoleTable).Single();
+        var kids = Dereference(table.Get(PdfName.K)) as PdfArray
+            ?? throw new InvalidOperationException("Expected table children to be an array.");
+
+        var rowObjects = new List<PdfObject>();
+        foreach (var item in kids)
+        {
+            if (Dereference(item) is PdfDictionary dict && RoleTr.Equals(dict.GetAsName(PdfName.S)))
+            {
+                rowObjects.Add(item);
+            }
+        }
+
+        rowObjects.Count.Should().BeGreaterThanOrEqualTo(3);
+
+        var thead = CreateStructElement(RoleTHead, table);
+        var tbody = CreateStructElement(RoleTBody, table);
+        var tfoot = CreateStructElement(RoleTFoot, table);
+
+        AddRowsToSection(thead, rowObjects.Take(1));
+        AddRowsToSection(tbody, rowObjects.Skip(1).Take(rowObjects.Count - 2));
+        AddRowsToSection(tfoot, rowObjects.TakeLast(1));
+
+        var sectionedKids = new PdfArray();
+        sectionedKids.Add(thead);
+        sectionedKids.Add(tbody);
+        sectionedKids.Add(tfoot);
+        table.Put(PdfName.K, sectionedKids);
+    }
+
+    private static PdfDictionary CreateStructElement(PdfName role, PdfDictionary parent)
+    {
+        var structElem = new PdfDictionary();
+        structElem.Put(PdfName.Type, new PdfName("StructElem"));
+        structElem.Put(PdfName.S, role);
+        structElem.Put(PdfName.P, parent);
+
+        var page = parent.Get(PdfName.Pg);
+        if (page is not null)
+        {
+            structElem.Put(PdfName.Pg, page);
+        }
+
+        return structElem;
+    }
+
+    private static void AddRowsToSection(PdfDictionary section, IEnumerable<PdfObject> rows)
+    {
+        var kids = new PdfArray();
+        foreach (var row in rows)
+        {
+            kids.Add(row);
+            if (Dereference(row) is PdfDictionary rowDict)
+            {
+                rowDict.Put(PdfName.P, section);
+            }
+        }
+
+        section.Put(PdfName.K, kids);
     }
 
     private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -16,6 +16,7 @@ namespace server.tests.Integration.Remediate;
 
 public sealed class PdfRemediationProcessorNoHeaderTableTests
 {
+    private const int MaxTestStructTreeTraversalNodes = 4096;
     private static readonly PdfName RoleTable = new("Table");
     private static readonly PdfName RoleTHead = new("THead");
     private static readonly PdfName RoleTBody = new("TBody");
@@ -390,6 +391,29 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             });
     }
 
+    [Fact]
+    public void ListStructElementsByRole_WhenStructTreeContainsCycle_StopsTraversal()
+    {
+        using var stream = new MemoryStream();
+        using var pdf = new PdfDocument(new PdfWriter(stream));
+        pdf.AddNewPage();
+
+        var structTreeRoot = new PdfDictionary();
+        structTreeRoot.Put(PdfName.Type, PdfName.StructTreeRoot);
+        structTreeRoot.MakeIndirect(pdf);
+        pdf.GetCatalog().GetPdfObject().Put(PdfName.StructTreeRoot, structTreeRoot);
+
+        var table = CreateTestStructElement(pdf, RoleTable);
+        var cell = CreateTestStructElement(pdf, RoleTd);
+        structTreeRoot.Put(PdfName.K, table.GetIndirectReference());
+        table.Put(PdfName.K, cell.GetIndirectReference());
+        cell.Put(PdfName.K, table.GetIndirectReference());
+
+        var cells = ListStructElementsByRole(pdf, RoleTd);
+
+        cells.Should().ContainSingle().Which.Should().BeSameAs(cell);
+    }
+
     private static async Task RunPdfTestAsync(
         string testName,
         Action<string> createPdf,
@@ -683,7 +707,7 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             return results;
         }
 
-        Traverse(rootKids, role, results);
+        Traverse(rootKids, role, results, new HashSet<(int Obj, int Gen)>());
         return results;
     }
 
@@ -745,42 +769,87 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
             && candidateRefFromDict.GetGenNumber() == targetRef.GetGenNumber();
     }
 
-    private static void Traverse(PdfObject node, PdfName role, List<PdfDictionary> results)
+    private static void Traverse(
+        PdfObject node,
+        PdfName role,
+        List<PdfDictionary> results,
+        HashSet<(int Obj, int Gen)> visited)
     {
-        var dereferenced = Dereference(node);
-        if (dereferenced is null)
-        {
-            return;
-        }
+        var stack = new Stack<PdfObject?>();
+        var nodesVisited = 0;
+        stack.Push(node);
 
-        node = dereferenced;
-
-        if (node is PdfArray array)
+        while (stack.Count > 0)
         {
-            foreach (var item in array)
+            if (++nodesVisited > MaxTestStructTreeTraversalNodes)
             {
-                Traverse(item, role, results);
+                return;
             }
 
-            return;
+            var current = stack.Pop();
+            if (current is null)
+            {
+                continue;
+            }
+
+            if (!TryMarkVisited(current, visited))
+            {
+                continue;
+            }
+
+            var dereferenced = Dereference(current);
+            if (dereferenced is null)
+            {
+                continue;
+            }
+
+            if (dereferenced is PdfArray array)
+            {
+                for (var i = array.Size() - 1; i >= 0; i--)
+                {
+                    stack.Push(array.Get(i));
+                }
+
+                continue;
+            }
+
+            if (dereferenced is not PdfDictionary dict)
+            {
+                continue;
+            }
+
+            var s = dict.GetAsName(PdfName.S);
+            if (role.Equals(s))
+            {
+                results.Add(dict);
+            }
+
+            var kids = dict.Get(PdfName.K);
+            if (kids is not null)
+            {
+                stack.Push(kids);
+            }
+        }
+    }
+
+    private static bool TryMarkVisited(PdfObject node, HashSet<(int Obj, int Gen)> visited)
+    {
+        if (node is PdfIndirectReference reference)
+        {
+            return visited.Add((reference.GetObjNumber(), reference.GetGenNumber()));
         }
 
-        if (node is not PdfDictionary dict)
-        {
-            return;
-        }
+        var objectReference = node.GetIndirectReference();
+        return objectReference is null
+            || visited.Add((objectReference.GetObjNumber(), objectReference.GetGenNumber()));
+    }
 
-        var s = dict.GetAsName(PdfName.S);
-        if (role.Equals(s))
-        {
-            results.Add(dict);
-        }
-
-        var kids = dict.Get(PdfName.K);
-        if (kids is not null)
-        {
-            Traverse(kids, role, results);
-        }
+    private static PdfDictionary CreateTestStructElement(PdfDocument pdf, PdfName role)
+    {
+        var dict = new PdfDictionary();
+        dict.Put(PdfName.S, role);
+        dict.MakeIndirect(pdf);
+        return dict;
     }
 
     private static PdfObject? Dereference(PdfObject? obj)

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -43,6 +43,60 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     }
 
     [Fact]
+    public async Task ProcessAsync_NoHeaderDataTable_WhenHeaderPromotionDisabled_LeavesTableUnchanged()
+    {
+        var runRoot = Path.Combine(
+            Path.GetTempPath(),
+            "readable-tests",
+            $"no-header-data-table-promotion-disabled-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateNoHeaderServiceDatesTablePdf(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var tableClassificationService = new QueuePdfTableClassificationService([
+                new PdfTableClassificationResult(PdfTableKind.DataTable, 0.95, "Looks like a data table."),
+            ]);
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
+                tableClassificationService,
+                new StablePdfTitleService(),
+                Options.Create(new PdfRemediationOptions
+                {
+                    PromoteFirstRowHeadersForNoHeaderTables = false,
+                }),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "no-header-data-table-promotion-disabled",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            ListStructElementsByRole(outputPdf, RoleTable).Should().HaveCount(1);
+            ListStructElementsByRole(outputPdf, RoleTHead).Should().BeEmpty();
+            ListStructElementsByRole(outputPdf, RoleTBody).Should().BeEmpty();
+            ListStructElementsByRole(outputPdf, RoleTr).Should().HaveCount(3);
+            ListStructElementsByRole(outputPdf, RoleTh).Should().BeEmpty();
+            ListStructElementsByRole(outputPdf, RoleTd).Should().HaveCount(9);
+            tableClassificationService.AssertAllResponsesConsumed();
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task ProcessAsync_NoHeaderFormLayoutTable_DemotesTableRoles()
     {
         await RunPdfTestAsync(

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTableSummaryTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTableSummaryTests.cs
@@ -81,8 +81,12 @@ public sealed class PdfRemediationProcessorTableSummaryTests
         using var doc = new Document(pdf);
 
         var table = new Table(UnitValue.CreatePercentArray([1f, 1f])).UseAllAvailableWidth();
-        table.AddHeaderCell(new Cell().Add(new Paragraph("Name")));
-        table.AddHeaderCell(new Cell().Add(new Paragraph("Age")));
+        var nameHeader = new Cell().Add(new Paragraph("Name"));
+        nameHeader.GetAccessibilityProperties().SetRole("TH");
+        var ageHeader = new Cell().Add(new Paragraph("Age"));
+        ageHeader.GetAccessibilityProperties().SetRole("TH");
+        table.AddHeaderCell(nameHeader);
+        table.AddHeaderCell(ageHeader);
         table.AddCell(new Cell().Add(new Paragraph("Alice")));
         table.AddCell(new Cell().Add(new Paragraph("30")));
 
@@ -251,4 +255,3 @@ public sealed class PdfRemediationProcessorTableSummaryTests
             throw new InvalidOperationException("Title service should not be called for table summary tests.");
     }
 }
-

--- a/tests/server.tests/Remediate/OpenAIPdfTableClassificationServiceTests.cs
+++ b/tests/server.tests/Remediate/OpenAIPdfTableClassificationServiceTests.cs
@@ -32,11 +32,56 @@ public sealed class OpenAIPdfTableClassificationServiceTests
         prompt.Should().Contain("[blank]");
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseResult_WhenResponseIsEmpty_Throws(string response)
+    {
+        var act = () => InvokeParseResult(response);
+
+        act.Should()
+            .Throw<TargetInvocationException>()
+            .Where(ex => ex.InnerException is InvalidOperationException
+                && ex.InnerException.Message == "Empty classifier response.");
+    }
+
+    [Fact]
+    public void ParseResult_WhenResponseIsInvalidJson_Throws()
+    {
+        var act = () => InvokeParseResult("not json");
+
+        act.Should()
+            .Throw<TargetInvocationException>()
+            .Where(ex => ex.InnerException is InvalidOperationException
+                && ex.InnerException.Message == "Classifier response was not valid JSON.");
+    }
+
+    [Fact]
+    public void ParseResult_WhenResponseIsValidJson_ReturnsClassification()
+    {
+        var result = InvokeParseResult(
+            """
+            {"kind":"data_table","confidence":0.8,"reason":"Rows and columns contain records."}
+            """);
+
+        result.Kind.Should().Be(PdfTableKind.DataTable);
+        result.Confidence.Should().Be(0.8);
+        result.Reason.Should().Be("Rows and columns contain records.");
+    }
+
     private static string InvokeBuildPrompt(PdfTableClassificationRequest request)
     {
         var method = typeof(OpenAIPdfTableClassificationService)
             .GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
 
         return (string)method.Invoke(null, [request])!;
+    }
+
+    private static PdfTableClassificationResult InvokeParseResult(string text)
+    {
+        var method = typeof(OpenAIPdfTableClassificationService)
+            .GetMethod("ParseResult", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return (PdfTableClassificationResult)method.Invoke(null, [text])!;
     }
 }

--- a/tests/server.tests/Remediate/OpenAIPdfTableClassificationServiceTests.cs
+++ b/tests/server.tests/Remediate/OpenAIPdfTableClassificationServiceTests.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using FluentAssertions;
+using server.core.Remediate.Table;
+
+namespace server.tests.Remediate;
+
+public sealed class OpenAIPdfTableClassificationServiceTests
+{
+    [Fact]
+    public void BuildPrompt_NormalizesBlanksAndTruncatesSampledCells()
+    {
+        var longCell = new string('x', 250);
+        var request = new PdfTableClassificationRequest(
+            RowCount: 1,
+            MaxColumnCount: 3,
+            HasNestedTable: false,
+            Rows:
+            [
+                [
+                    longCell,
+                    "  Alpha\n\tBeta  ",
+                    "   ",
+                ],
+            ],
+            PrimaryLanguage: null);
+
+        var prompt = InvokeBuildPrompt(request);
+
+        prompt.Should().Contain($"{new string('x', 200)}...");
+        prompt.Should().NotContain(new string('x', 201));
+        prompt.Should().Contain("Alpha Beta");
+        prompt.Should().Contain("[blank]");
+    }
+
+    private static string InvokeBuildPrompt(PdfTableClassificationRequest request)
+    {
+        var method = typeof(OpenAIPdfTableClassificationService)
+            .GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return (string)method.Invoke(null, [request])!;
+    }
+}

--- a/tests/server.tests/Remediate/PdfRemediationOptionsTests.cs
+++ b/tests/server.tests/Remediate/PdfRemediationOptionsTests.cs
@@ -16,4 +16,10 @@ public sealed class PdfRemediationOptionsTests
     {
         new PdfRemediationOptions().NoHeaderTableClassificationTimeoutSeconds.Should().Be(30);
     }
+
+    [Fact]
+    public void Defaults_PromoteFirstRowHeadersForNoHeaderTables_IsTrue()
+    {
+        new PdfRemediationOptions().PromoteFirstRowHeadersForNoHeaderTables.Should().BeTrue();
+    }
 }

--- a/tests/server.tests/Remediate/PdfRemediationOptionsTests.cs
+++ b/tests/server.tests/Remediate/PdfRemediationOptionsTests.cs
@@ -10,5 +10,10 @@ public sealed class PdfRemediationOptionsTests
     {
         new PdfRemediationOptions().DemoteSmallTablesWithoutHeaders.Should().BeTrue();
     }
-}
 
+    [Fact]
+    public void Defaults_NoHeaderTableClassificationTimeoutSeconds_IsThirty()
+    {
+        new PdfRemediationOptions().NoHeaderTableClassificationTimeoutSeconds.Should().Be(30);
+    }
+}

--- a/tests/server.tests/Remediate/PdfTableRoleRemediatorTraversalTests.cs
+++ b/tests/server.tests/Remediate/PdfTableRoleRemediatorTraversalTests.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Reflection;
+using FluentAssertions;
+using iText.Kernel.Pdf;
+using server.core.Remediate;
+
+namespace server.tests.Remediate;
+
+public sealed class PdfTableRoleRemediatorTraversalTests
+{
+    [Fact]
+    public void ListMarkedContentRefs_WhenStructElementKidsCycle_StopsTraversal()
+    {
+        var structElem = new PdfDictionary();
+        structElem.Put(PdfName.S, new PdfName("TD"));
+        structElem.Put(PdfName.K, structElem);
+
+        var method = typeof(PdfRemediationProcessor)
+            .Assembly
+            .GetType("server.core.Remediate.PdfTableRoleRemediator")!
+            .GetMethod("ListMarkedContentRefs", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var refs = ((IEnumerable)method.Invoke(
+            null,
+            [structElem, new Dictionary<int, int>(), CancellationToken.None])!).Cast<object>();
+
+        refs.Should().BeEmpty();
+    }
+}

--- a/tests/server.tests/Remediate/PdfTableRoleRemediatorTraversalTests.cs
+++ b/tests/server.tests/Remediate/PdfTableRoleRemediatorTraversalTests.cs
@@ -8,6 +8,9 @@ namespace server.tests.Remediate;
 
 public sealed class PdfTableRoleRemediatorTraversalTests
 {
+    private static readonly PdfName RoleTable = new("Table");
+    private static readonly PdfName RoleTd = new("TD");
+
     [Fact]
     public void ListMarkedContentRefs_WhenStructElementKidsCycle_StopsTraversal()
     {
@@ -25,5 +28,77 @@ public sealed class PdfTableRoleRemediatorTraversalTests
             [structElem, new Dictionary<int, int>(), CancellationToken.None])!).Cast<object>();
 
         refs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindStructElementParent_WhenStructElementKidsCycle_StopsTraversal()
+    {
+        using var stream = new MemoryStream();
+        using var pdf = new PdfDocument(new PdfWriter(stream));
+        pdf.AddNewPage();
+        var root = CreateStructElement(pdf, RoleTable);
+        var child = CreateStructElement(pdf, RoleTd);
+        var missingTarget = CreateStructElement(pdf, RoleTd);
+        root.Put(PdfName.K, child.GetIndirectReference());
+        child.Put(PdfName.K, root.GetIndirectReference());
+
+        var method = GetRemediatorMethod("FindStructElementParent");
+
+        var parent = method.Invoke(null, [root, missingTarget, CancellationToken.None]);
+
+        parent.Should().BeNull();
+    }
+
+    [Fact]
+    public void ListDescendantStructElementsByRole_WhenStructElementKidsCycle_StopsTraversal()
+    {
+        using var stream = new MemoryStream();
+        using var pdf = new PdfDocument(new PdfWriter(stream));
+        pdf.AddNewPage();
+        var root = CreateStructElement(pdf, RoleTable);
+        var child = CreateStructElement(pdf, RoleTd);
+        root.Put(PdfName.K, child.GetIndirectReference());
+        child.Put(PdfName.K, root.GetIndirectReference());
+
+        var method = GetRemediatorMethod("ListDescendantStructElementsByRole");
+
+        var descendants = ((IEnumerable)method.Invoke(
+            null,
+            [root, RoleTd, CancellationToken.None])!).Cast<PdfDictionary>();
+
+        descendants.Should().ContainSingle().Which.Should().BeSameAs(child);
+    }
+
+    [Fact]
+    public void TraverseTagTreeForList_WhenStructElementKidsCycle_StopsTraversal()
+    {
+        using var stream = new MemoryStream();
+        using var pdf = new PdfDocument(new PdfWriter(stream));
+        pdf.AddNewPage();
+        var root = CreateStructElement(pdf, RoleTable);
+        var child = CreateStructElement(pdf, RoleTd);
+        root.Put(PdfName.K, child.GetIndirectReference());
+        child.Put(PdfName.K, root.GetIndirectReference());
+
+        var results = new List<PdfDictionary>();
+        var method = GetRemediatorMethod("TraverseTagTreeForList");
+
+        method.Invoke(null, [root.Get(PdfName.K), RoleTd, results, CancellationToken.None]);
+
+        results.Should().ContainSingle().Which.Should().BeSameAs(child);
+    }
+
+    private static MethodInfo GetRemediatorMethod(string name) =>
+        typeof(PdfRemediationProcessor)
+            .Assembly
+            .GetType("server.core.Remediate.PdfTableRoleRemediator")!
+            .GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static PdfDictionary CreateStructElement(PdfDocument pdf, PdfName role)
+    {
+        var dict = new PdfDictionary();
+        dict.Put(PdfName.S, role);
+        dict.MakeIndirect(pdf);
+        return dict;
     }
 }


### PR DESCRIPTION
## Summary

This PR tightens the PDF no-header table remediation flow and addresses the review items from `srk/table-headers`:

- demotes table section roles (`/THead`, `/TBody`, `/TFoot`) along with table, row, and cell roles
- hardens marked-content and demotion traversals against malformed cyclic/deep tag trees
- adds a configurable per-table classification timeout and leaves tables unchanged on timeout/failure
- wires `PromoteFirstRowHeadersForNoHeaderTables` into behavior
- strengthens tests for classifier request text, demotion opt-out, `/K` and `/P` tag-tree structure, and classifier reason logging

## Validation

- `dotnet build`
- `dotnet test`

Both passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered table classification added to remediate PDF tables without headers, with options to promote first-row headers or demote non-data tables.
  * Configurable per-table classification timeout and remediation behavior.

* **Tests**
  * Extensive integration and unit tests covering promotion, demotion, timeouts, traversal/cycle safety, and classifier parsing.

* **Documentation**
  * Updated remarks to document new configuration/environment variable for model selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->