### PR TITLE
Streamlines PDF figure alt text generation

### DIFF
--- a/server.core/Remediate/Figures/PdfDecorativeFigureTracker.cs
+++ b/server.core/Remediate/Figures/PdfDecorativeFigureTracker.cs
@@ -29,6 +29,25 @@ internal sealed class PdfDecorativeFigureTracker
 
     public int Total => Removed + Demoted;
 
+    public bool Demote(PdfDictionary figure, string reason, int? pageNumber = null)
+    {
+        if (!_demotedOrRemovedFigures.Add(figure))
+        {
+            return false;
+        }
+
+        figure.Remove(PdfName.Alt);
+        figure.Put(PdfName.S, RoleSpan);
+        Demoted++;
+        _logger.LogInformation(
+            "Demoted decorative figure in {fileId}: page={pageNumber} reason={reason}",
+            _fileId,
+            pageNumber,
+            reason);
+
+        return true;
+    }
+
     public bool RemoveOrDemote(PdfDictionary figure, string reason, int? pageNumber = null)
     {
         if (!_demotedOrRemovedFigures.Add(figure))
@@ -86,6 +105,37 @@ internal sealed class PdfDecorativeFigureTracker
         foreach (var repeatedFigure in figures)
         {
             changed |= RemoveOrDemote(repeatedFigure, reason, pageNumber);
+        }
+
+        return changed;
+    }
+
+    public bool DemoteRepeatedChromeFigure(
+        PdfDictionary figure,
+        string signature,
+        string reason,
+        int pageNumber)
+    {
+        if (!_repeatedChromeFiguresBySignature.TryGetValue(signature, out var figures))
+        {
+            figures = new List<PdfDictionary>();
+            _repeatedChromeFiguresBySignature[signature] = figures;
+        }
+
+        if (!figures.Contains(figure, PdfDictionaryReferenceComparer.Instance))
+        {
+            figures.Add(figure);
+        }
+
+        if (figures.Count < PdfFigureVisualHeuristics.RepeatedFigureChromeThreshold)
+        {
+            return false;
+        }
+
+        var changed = false;
+        foreach (var repeatedFigure in figures)
+        {
+            changed |= Demote(repeatedFigure, reason, pageNumber);
         }
 
         return changed;

--- a/server.core/Remediate/Figures/PdfDecorativeFigureTracker.cs
+++ b/server.core/Remediate/Figures/PdfDecorativeFigureTracker.cs
@@ -27,6 +27,8 @@ internal sealed class PdfDecorativeFigureTracker
 
     public int Demoted { get; private set; }
 
+    public int Total => Removed + Demoted;
+
     public bool RemoveOrDemote(PdfDictionary figure, string reason, int? pageNumber = null)
     {
         if (!_demotedOrRemovedFigures.Add(figure))

--- a/server.core/Remediate/Figures/PdfDecorativeFigureTracker.cs
+++ b/server.core/Remediate/Figures/PdfDecorativeFigureTracker.cs
@@ -1,0 +1,91 @@
+using iText.Kernel.Pdf;
+using Microsoft.Extensions.Logging;
+
+namespace server.core.Remediate.Figures;
+
+internal sealed class PdfDecorativeFigureTracker
+{
+    private static readonly PdfName RoleSpan = new("Span");
+
+    private readonly HashSet<PdfDictionary> _demotedOrRemovedFigures = new(PdfDictionaryReferenceComparer.Instance);
+    private readonly string _fileId;
+    private readonly ILogger _logger;
+    private readonly Dictionary<string, List<PdfDictionary>> _repeatedChromeFiguresBySignature = new(StringComparer.Ordinal);
+    private readonly Func<PdfDictionary, bool> _tryRemoveStructElemFromParent;
+
+    public PdfDecorativeFigureTracker(
+        string fileId,
+        ILogger logger,
+        Func<PdfDictionary, bool> tryRemoveStructElemFromParent)
+    {
+        _fileId = fileId;
+        _logger = logger;
+        _tryRemoveStructElemFromParent = tryRemoveStructElemFromParent;
+    }
+
+    public int Removed { get; private set; }
+
+    public int Demoted { get; private set; }
+
+    public bool RemoveOrDemote(PdfDictionary figure, string reason, int? pageNumber = null)
+    {
+        if (!_demotedOrRemovedFigures.Add(figure))
+        {
+            return false;
+        }
+
+        figure.Remove(PdfName.Alt);
+        if (_tryRemoveStructElemFromParent(figure))
+        {
+            Removed++;
+            _logger.LogInformation(
+                "Removed decorative figure from structure tree in {fileId}: page={pageNumber} reason={reason}",
+                _fileId,
+                pageNumber,
+                reason);
+        }
+        else
+        {
+            figure.Put(PdfName.S, RoleSpan);
+            Demoted++;
+            _logger.LogInformation(
+                "Demoted decorative figure in {fileId}: page={pageNumber} reason={reason}",
+                _fileId,
+                pageNumber,
+                reason);
+        }
+
+        return true;
+    }
+
+    public bool RemoveOrDemoteRepeatedChromeFigure(
+        PdfDictionary figure,
+        string signature,
+        string reason,
+        int pageNumber)
+    {
+        if (!_repeatedChromeFiguresBySignature.TryGetValue(signature, out var figures))
+        {
+            figures = new List<PdfDictionary>();
+            _repeatedChromeFiguresBySignature[signature] = figures;
+        }
+
+        if (!figures.Contains(figure, PdfDictionaryReferenceComparer.Instance))
+        {
+            figures.Add(figure);
+        }
+
+        if (figures.Count < PdfFigureVisualHeuristics.RepeatedFigureChromeThreshold)
+        {
+            return false;
+        }
+
+        var changed = false;
+        foreach (var repeatedFigure in figures)
+        {
+            changed |= RemoveOrDemote(repeatedFigure, reason, pageNumber);
+        }
+
+        return changed;
+    }
+}

--- a/server.core/Remediate/Figures/PdfDictionaryReferenceComparer.cs
+++ b/server.core/Remediate/Figures/PdfDictionaryReferenceComparer.cs
@@ -1,0 +1,13 @@
+using System.Runtime.CompilerServices;
+using iText.Kernel.Pdf;
+
+namespace server.core.Remediate.Figures;
+
+internal sealed class PdfDictionaryReferenceComparer : IEqualityComparer<PdfDictionary>
+{
+    public static PdfDictionaryReferenceComparer Instance { get; } = new();
+
+    public bool Equals(PdfDictionary? x, PdfDictionary? y) => ReferenceEquals(x, y);
+
+    public int GetHashCode(PdfDictionary obj) => RuntimeHelpers.GetHashCode(obj);
+}

--- a/server.core/Remediate/Figures/PdfFigureVisualHeuristics.cs
+++ b/server.core/Remediate/Figures/PdfFigureVisualHeuristics.cs
@@ -1,0 +1,158 @@
+using System.Security.Cryptography;
+using System.Text;
+using iText.Kernel.Geom;
+using server.core.Remediate.Rasterize;
+
+namespace server.core.Remediate.Figures;
+
+internal static class PdfFigureVisualHeuristics
+{
+    public const int RepeatedFigureChromeThreshold = 3;
+
+    private const double TinyFigureAreaRatio = 0.001;
+    private const float TinyFigureMinDimensionPts = 12f;
+    private const double LowInformationDominantColorRatio = 0.985;
+    private const double LowInformationNonBackgroundRatio = 0.015;
+
+    public static bool IsTinyFigureBounds(Rectangle boundsPts, Rectangle pageSizePts, out string reason)
+    {
+        reason = string.Empty;
+
+        var figureWidth = boundsPts.GetWidth();
+        var figureHeight = boundsPts.GetHeight();
+        var pageArea = pageSizePts.GetWidth() * pageSizePts.GetHeight();
+        var figureArea = figureWidth * figureHeight;
+
+        if (figureWidth <= 0 || figureHeight <= 0 || pageArea <= 0)
+        {
+            reason = "figure has invalid visual bounds";
+            return true;
+        }
+
+        if (figureWidth < TinyFigureMinDimensionPts || figureHeight < TinyFigureMinDimensionPts)
+        {
+            reason = "figure visual bounds are too small for useful alt text";
+            return true;
+        }
+
+        if (figureArea / pageArea < TinyFigureAreaRatio)
+        {
+            reason = "figure visual area is too small for useful alt text";
+            return true;
+        }
+
+        return false;
+    }
+
+    public static string? BuildRepeatedChromeSignature(string visualHash, Rectangle boundsPts, Rectangle pageSizePts)
+    {
+        var pageWidth = pageSizePts.GetWidth();
+        var pageHeight = pageSizePts.GetHeight();
+        if (string.IsNullOrWhiteSpace(visualHash) || pageWidth <= 0 || pageHeight <= 0)
+        {
+            return null;
+        }
+
+        static int Bucket(float value, float extent) => (int)Math.Round(value / extent * 1000f, MidpointRounding.AwayFromZero);
+
+        var x = Bucket(boundsPts.GetX(), pageWidth);
+        var y = Bucket(boundsPts.GetY(), pageHeight);
+        var w = Bucket(boundsPts.GetWidth(), pageWidth);
+        var h = Bucket(boundsPts.GetHeight(), pageHeight);
+        return $"{visualHash}:{x}:{y}:{w}:{h}";
+    }
+
+    public static bool TryClassifyLowInformationBitmap(BgraBitmap bitmap, out string reason)
+    {
+        reason = string.Empty;
+        if (!bitmap.IsValid)
+        {
+            reason = "figure crop is invalid";
+            return true;
+        }
+
+        var totalPixels = bitmap.WidthPx * bitmap.HeightPx;
+        if (totalPixels <= 0)
+        {
+            reason = "figure crop is empty";
+            return true;
+        }
+
+        var backgroundLikePixels = 0;
+        var nonBackgroundPixels = 0;
+        var minNonBackgroundX = bitmap.WidthPx;
+        var minNonBackgroundY = bitmap.HeightPx;
+        var maxNonBackgroundX = -1;
+        var maxNonBackgroundY = -1;
+        var colorCounts = new Dictionary<int, int>();
+
+        for (var y = 0; y < bitmap.HeightPx; y++)
+        {
+            var rowOffset = y * bitmap.StrideBytes;
+            for (var x = 0; x < bitmap.WidthPx; x++)
+            {
+                var offset = rowOffset + (x * 4);
+                var b = bitmap.BgraBytes[offset + 0];
+                var g = bitmap.BgraBytes[offset + 1];
+                var r = bitmap.BgraBytes[offset + 2];
+                var a = bitmap.BgraBytes[offset + 3];
+
+                var colorKey = ((r >> 4) << 8) | ((g >> 4) << 4) | (b >> 4);
+                colorCounts[colorKey] = colorCounts.TryGetValue(colorKey, out var count) ? count + 1 : 1;
+
+                if (IsBackgroundLikePixel(r, g, b, a))
+                {
+                    backgroundLikePixels++;
+                    continue;
+                }
+
+                nonBackgroundPixels++;
+                minNonBackgroundX = Math.Min(minNonBackgroundX, x);
+                minNonBackgroundY = Math.Min(minNonBackgroundY, y);
+                maxNonBackgroundX = Math.Max(maxNonBackgroundX, x);
+                maxNonBackgroundY = Math.Max(maxNonBackgroundY, y);
+            }
+        }
+
+        if (backgroundLikePixels / (double)totalPixels >= LowInformationDominantColorRatio)
+        {
+            reason = "figure crop is blank or mostly page background";
+            return true;
+        }
+
+        if (nonBackgroundPixels / (double)totalPixels <= LowInformationNonBackgroundRatio)
+        {
+            reason = "figure crop has too little visible content";
+            return true;
+        }
+
+        var dominantColorPixels = colorCounts.Values.Count == 0 ? 0 : colorCounts.Values.Max();
+        if (dominantColorPixels / (double)totalPixels >= LowInformationDominantColorRatio)
+        {
+            reason = "figure crop is nearly a single flat color";
+            return true;
+        }
+
+        var nonBackgroundWidth = maxNonBackgroundX - minNonBackgroundX + 1;
+        var nonBackgroundHeight = maxNonBackgroundY - minNonBackgroundY + 1;
+        if (nonBackgroundWidth <= 3 || nonBackgroundHeight <= 3)
+        {
+            reason = "figure crop is a thin visual rule";
+            return true;
+        }
+
+        return false;
+    }
+
+    public static string ComputeBitmapHash(BgraBitmap bitmap)
+    {
+        var prefix = Encoding.ASCII.GetBytes($"{bitmap.WidthPx}x{bitmap.HeightPx}x{bitmap.StrideBytes}:");
+        var bytes = new byte[prefix.Length + bitmap.BgraBytes.Length];
+        Buffer.BlockCopy(prefix, 0, bytes, 0, prefix.Length);
+        Buffer.BlockCopy(bitmap.BgraBytes, 0, bytes, prefix.Length, bitmap.BgraBytes.Length);
+        return Convert.ToHexString(SHA256.HashData(bytes));
+    }
+
+    private static bool IsBackgroundLikePixel(byte r, byte g, byte b, byte a)
+        => a <= 8 || (r >= 245 && g >= 245 && b >= 245);
+}

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
-using System.Runtime.CompilerServices;
 using iText.IO.Font;
 using iText.Kernel.Geom;
 using iText.Kernel.Pdf;
@@ -15,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using IOPath = System.IO.Path;
 using server.core.Remediate.AltText;
 using server.core.Remediate.Bookmarks;
+using server.core.Remediate.Figures;
 using server.core.Remediate.Rasterize;
 using server.core.Remediate.Table;
 using server.core.Remediate.Title;
@@ -170,9 +170,9 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
     /// Remediates a PDF by ensuring it has a title and (when tagged) adding missing alt text for figures (and optionally links).
     /// </summary>
     /// <remarks>
-    /// Alt-text remediation relies on the PDF tag tree, so it only runs for tagged PDFs. A fallback pass ensures
-    /// any remaining <c>/Figure</c> structure elements have some <c>/Alt</c> value even when exact content-to-tag
-    /// matching is imperfect. Link <c>/Alt</c> generation is opt-in via <see cref="PdfRemediationOptions" />.
+    /// Alt-text remediation relies on the PDF tag tree, so it only runs for tagged PDFs. Obvious decorative or broken
+    /// <c>/Figure</c> structure elements are removed or demoted before expensive AI alt-text generation. Link
+    /// <c>/Alt</c> generation is opt-in via <see cref="PdfRemediationOptions" />.
     /// </remarks>
     public async Task<PdfRemediationResult> ProcessAsync(
         string fileId,
@@ -350,6 +350,22 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                 figureIndex = PdfStructTreeIndex.BuildForRole(pdf, pageObjNumToPageNumber, PdfName.Figure);
             }
 
+            var decorativeFigureAltSkipped = 0;
+            var decorativeFigures = new PdfDecorativeFigureTracker(fileId, _logger, TryRemoveStructElemFromParent);
+
+            foreach (var figure in PdfStructTreeIndex.ListStructElementsByRole(pdf, PdfName.Figure))
+            {
+                if (StructElemHasAssociatedContent(figure))
+                {
+                    continue;
+                }
+
+                if (decorativeFigures.RemoveOrDemote(figure, "figure has no associated content"))
+                {
+                    decorativeFigureAltSkipped++;
+                }
+            }
+
             var linkIndex = _options.GenerateLinkAltText
                 ? PdfStructTreeIndex.BuildForRole(pdf, pageObjNumToPageNumber, PdfName.Link)
                 : null;
@@ -385,16 +401,43 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                             continue;
                         }
 
+                        if (occ.Bounds is not null
+                            && PdfFigureVisualHeuristics.IsTinyFigureBounds(occ.Bounds, page.GetPageSizeWithRotation(), out var tinyReason))
+                        {
+                            if (decorativeFigures.RemoveOrDemote(figure, tinyReason, pageNumber))
+                            {
+                                decorativeFigureAltSkipped++;
+                            }
+
+                            continue;
+                        }
+
                         var (bytes, mimeType) = ExtractImageBytes(occ.Image);
                         if (!IsSupportedAltTextImageMimeType(mimeType))
                         {
                             imageAltSkippedUnsupported++;
-                            _logger.LogWarning(
-                                "Skipping raster image alt text for {fileId} page={pageNumber}: unsupported image MIME type {mimeType}. Figure will remain without Alt for manual remediation.",
-                                fileId,
-                                pageNumber,
-                                mimeType);
+                            if (decorativeFigures.RemoveOrDemote(figure, $"unsupported image MIME type {mimeType}", pageNumber))
+                            {
+                                decorativeFigureAltSkipped++;
+                            }
+
                             continue;
+                        }
+
+                        if (occ.Bounds is not null)
+                        {
+                            var imageHash = Convert.ToHexString(SHA256.HashData(bytes));
+                            var repeatedSignature = PdfFigureVisualHeuristics.BuildRepeatedChromeSignature(imageHash, occ.Bounds, page.GetPageSizeWithRotation());
+                            if (repeatedSignature is not null
+                                && decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
+                                    figure,
+                                    repeatedSignature,
+                                    "same image appears repeatedly in the same page position",
+                                    pageNumber))
+                            {
+                                decorativeFigureAltSkipped++;
+                                continue;
+                            }
                         }
 
                         string altText;
@@ -626,6 +669,16 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                                             continue;
                                         }
 
+                                        if (PdfFigureVisualHeuristics.IsTinyFigureBounds(candidate.BoundsPts, pageSizePts, out var tinyReason))
+                                        {
+                                            if (decorativeFigures.RemoveOrDemote(candidate.Figure, tinyReason, pageNumber))
+                                            {
+                                                decorativeFigureAltSkipped++;
+                                            }
+
+                                            continue;
+                                        }
+
                                         var cropRectPx = TryComputeCropRectPx(candidate.BoundsPts, pageSizePts, pageBitmap, minSizePx: 64, padPts: 2f);
                                         if (cropRectPx is null || cropRectPx.Value.IsEmpty)
                                         {
@@ -647,6 +700,29 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                                         if (!cropBitmap.IsValid)
                                         {
                                             vectorRasterFailures++;
+                                            continue;
+                                        }
+
+                                        if (PdfFigureVisualHeuristics.TryClassifyLowInformationBitmap(cropBitmap, out var lowInformationReason))
+                                        {
+                                            if (decorativeFigures.RemoveOrDemote(candidate.Figure, lowInformationReason, pageNumber))
+                                            {
+                                                decorativeFigureAltSkipped++;
+                                            }
+
+                                            continue;
+                                        }
+
+                                        var bitmapHash = PdfFigureVisualHeuristics.ComputeBitmapHash(cropBitmap);
+                                        var repeatedSignature = PdfFigureVisualHeuristics.BuildRepeatedChromeSignature(bitmapHash, candidate.BoundsPts, pageSizePts);
+                                        if (repeatedSignature is not null
+                                            && decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
+                                                candidate.Figure,
+                                                repeatedSignature,
+                                                "same visual crop appears repeatedly in the same page position",
+                                                pageNumber))
+                                        {
+                                            decorativeFigureAltSkipped++;
                                             continue;
                                         }
 
@@ -790,12 +866,15 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
             }
 
             _logger.LogInformation(
-                "PDF remediation image alt summary: {fileId} imageOccurrences={imageOccurrences} imageAltSet={imageAltSet} imageAltSkippedUnsupported={imageAltSkippedUnsupported} imageAltFailures={imageAltFailures} remainingFiguresMissingAlt={remainingFiguresMissingAlt} contentlessFiguresRemoved={contentlessFiguresRemoved} contentlessFiguresDemoted={contentlessFiguresDemoted}",
+                "PDF remediation image alt summary: {fileId} imageOccurrences={imageOccurrences} imageAltSet={imageAltSet} imageAltSkippedUnsupported={imageAltSkippedUnsupported} imageAltFailures={imageAltFailures} decorativeFigureAltSkipped={decorativeFigureAltSkipped} decorativeFiguresRemoved={decorativeFiguresRemoved} decorativeFiguresDemoted={decorativeFiguresDemoted} remainingFiguresMissingAlt={remainingFiguresMissingAlt} contentlessFiguresRemoved={contentlessFiguresRemoved} contentlessFiguresDemoted={contentlessFiguresDemoted}",
                 fileId,
                 imageOccurrences,
                 imageAltSet,
                 imageAltSkippedUnsupported,
                 imageAltFailures,
+                decorativeFigureAltSkipped,
+                decorativeFigures.Removed,
+                decorativeFigures.Demoted,
                 remainingFiguresMissingAlt,
                 contentlessFiguresRemoved,
                 contentlessFiguresDemoted);
@@ -1403,15 +1482,6 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
         structElem.Put(PdfName.Alt, new PdfString(altText, PdfEncodings.UNICODE_BIG));
     }
 
-    private sealed class PdfDictionaryReferenceComparer : IEqualityComparer<PdfDictionary>
-    {
-        public static PdfDictionaryReferenceComparer Instance { get; } = new();
-
-        public bool Equals(PdfDictionary? x, PdfDictionary? y) => ReferenceEquals(x, y);
-
-        public int GetHashCode(PdfDictionary obj) => RuntimeHelpers.GetHashCode(obj);
-    }
-
     private sealed class VectorFigureCandidate
     {
         public VectorFigureCandidate(PdfDictionary figure, Rectangle boundsPts, string contextBefore, string contextAfter)
@@ -1535,6 +1605,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
         int Mcid,
         PdfImageXObject Image,
         PdfIndirectReference? ObjectRef,
+        Rectangle? Bounds,
         string ContextBefore,
         string ContextAfter);
 
@@ -1682,12 +1753,14 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                 var image = imageRenderInfo.GetImage();
                 var imageRef = image.GetPdfObject().GetIndirectReference();
+                var bounds = TryGetImageBounds(imageRenderInfo);
 
                 _pending.Add(
                     new PendingImageOccurrence(
                         imageRenderInfo.GetMcid(),
                         image,
                         imageRef,
+                        bounds,
                         TextCharIndex: _pageText.Length));
             }
 
@@ -1711,15 +1784,78 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                             pending.Mcid,
                             pending.Image,
                             pending.ImageRef,
+                            pending.Bounds,
                             ContextBefore: before,
                             ContextAfter: after));
                 }
 
                 return occurrences;
             }
+
+            private static Rectangle? TryGetImageBounds(ImageRenderInfo imageRenderInfo)
+            {
+                try
+                {
+                    var ctm = imageRenderInfo.GetImageCtm();
+                    var any = false;
+                    double minX = 0, minY = 0, maxX = 0, maxY = 0;
+
+                    AddUnitSquarePoint(0, 0, ctm, ref any, ref minX, ref minY, ref maxX, ref maxY);
+                    AddUnitSquarePoint(1, 0, ctm, ref any, ref minX, ref minY, ref maxX, ref maxY);
+                    AddUnitSquarePoint(0, 1, ctm, ref any, ref minX, ref minY, ref maxX, ref maxY);
+                    AddUnitSquarePoint(1, 1, ctm, ref any, ref minX, ref minY, ref maxX, ref maxY);
+
+                    return any && maxX > minX && maxY > minY
+                        ? new Rectangle((float)minX, (float)minY, (float)(maxX - minX), (float)(maxY - minY))
+                        : null;
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            private static void AddUnitSquarePoint(
+                double x,
+                double y,
+                iText.Kernel.Geom.Matrix m,
+                ref bool any,
+                ref double minX,
+                ref double minY,
+                ref double maxX,
+                ref double maxY)
+            {
+                var a = m.Get(iText.Kernel.Geom.Matrix.I11);
+                var b = m.Get(iText.Kernel.Geom.Matrix.I12);
+                var c = m.Get(iText.Kernel.Geom.Matrix.I21);
+                var d = m.Get(iText.Kernel.Geom.Matrix.I22);
+                var e = m.Get(iText.Kernel.Geom.Matrix.I31);
+                var f = m.Get(iText.Kernel.Geom.Matrix.I32);
+
+                var tx = (a * x) + (c * y) + e;
+                var ty = (b * x) + (d * y) + f;
+
+                if (!any)
+                {
+                    any = true;
+                    minX = maxX = tx;
+                    minY = maxY = ty;
+                    return;
+                }
+
+                minX = Math.Min(minX, tx);
+                minY = Math.Min(minY, ty);
+                maxX = Math.Max(maxX, tx);
+                maxY = Math.Max(maxY, ty);
+            }
         }
 
-        private sealed record PendingImageOccurrence(int Mcid, PdfImageXObject Image, PdfIndirectReference? ImageRef, int TextCharIndex);
+        private sealed record PendingImageOccurrence(
+            int Mcid,
+            PdfImageXObject Image,
+            PdfIndirectReference? ImageRef,
+            Rectangle? Bounds,
+            int TextCharIndex);
 
         private sealed class VectorFigureOccurrenceListener : IEventListener
         {

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -411,7 +411,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         if (occ.Bounds is not null
                             && PdfFigureVisualHeuristics.IsTinyFigureBounds(occ.Bounds, page.GetPageSizeWithRotation(), out var tinyReason))
                         {
-                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(figure, tinyReason, pageNumber));
+                            var changeCount = CountDecorativeChanges(() => decorativeFigures.Demote(figure, tinyReason, pageNumber));
                             if (changeCount > 0)
                             {
                                 decorativeFigureAltSkipped += changeCount;
@@ -424,7 +424,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         if (!IsSupportedAltTextImageMimeType(mimeType))
                         {
                             imageAltSkippedUnsupported++;
-                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(figure, $"unsupported image MIME type {mimeType}", pageNumber));
+                            var changeCount = CountDecorativeChanges(() => decorativeFigures.Demote(figure, $"unsupported image MIME type {mimeType}", pageNumber));
                             if (changeCount > 0)
                             {
                                 decorativeFigureAltSkipped += changeCount;
@@ -440,7 +440,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                             if (repeatedSignature is not null)
                             {
                                 var changeCount = CountDecorativeChanges(
-                                    () => decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
+                                    () => decorativeFigures.DemoteRepeatedChromeFigure(
                                         figure,
                                         repeatedSignature,
                                         "same image appears repeatedly in the same page position",
@@ -684,7 +684,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                                         if (PdfFigureVisualHeuristics.IsTinyFigureBounds(candidate.BoundsPts, pageSizePts, out var tinyReason))
                                         {
-                                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(candidate.Figure, tinyReason, pageNumber));
+                                            var changeCount = CountDecorativeChanges(() => decorativeFigures.Demote(candidate.Figure, tinyReason, pageNumber));
                                             if (changeCount > 0)
                                             {
                                                 decorativeFigureAltSkipped += changeCount;
@@ -719,7 +719,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                                         if (PdfFigureVisualHeuristics.TryClassifyLowInformationBitmap(cropBitmap, out var lowInformationReason))
                                         {
-                                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(candidate.Figure, lowInformationReason, pageNumber));
+                                            var changeCount = CountDecorativeChanges(() => decorativeFigures.Demote(candidate.Figure, lowInformationReason, pageNumber));
                                             if (changeCount > 0)
                                             {
                                                 decorativeFigureAltSkipped += changeCount;
@@ -733,7 +733,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                                         if (repeatedSignature is not null)
                                         {
                                             var changeCount = CountDecorativeChanges(
-                                                () => decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
+                                                () => decorativeFigures.DemoteRepeatedChromeFigure(
                                                     candidate.Figure,
                                                     repeatedSignature,
                                                     "same visual crop appears repeatedly in the same page position",

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -356,6 +356,8 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
             var imageOccurrences = 0;
             var imageAltSet = 0;
+            var imageAltSkippedUnsupported = 0;
+            var imageAltFailures = 0;
             var linkOccurrences = 0;
             var linkAltSet = 0;
 
@@ -384,9 +386,39 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         }
 
                         var (bytes, mimeType) = ExtractImageBytes(occ.Image);
-                        var altText = await _altTextService.GetAltTextForImageAsync(
-                            new ImageAltTextRequest(bytes, mimeType, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
-                            cancellationToken);
+                        if (!IsSupportedAltTextImageMimeType(mimeType))
+                        {
+                            imageAltSkippedUnsupported++;
+                            _logger.LogWarning(
+                                "Skipping raster image alt text for {fileId} page={pageNumber}: unsupported image MIME type {mimeType}. Figure will remain without Alt for manual remediation.",
+                                fileId,
+                                pageNumber,
+                                mimeType);
+                            continue;
+                        }
+
+                        string altText;
+                        try
+                        {
+                            altText = await _altTextService.GetAltTextForImageAsync(
+                                new ImageAltTextRequest(bytes, mimeType, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
+                                cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception ex)
+                        {
+                            imageAltFailures++;
+                            _logger.LogWarning(
+                                ex,
+                                "Failed to generate raster image alt text for {fileId} page={pageNumber}. Figure will remain without Alt for manual remediation.",
+                                fileId,
+                                pageNumber);
+                            continue;
+                        }
+
                         SetAlt(figure, altText);
                         if (!string.IsNullOrWhiteSpace(altText))
                         {
@@ -689,9 +721,9 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                 }
             }
 
-            // Fallback safety-net: ensure any remaining tagged Figures get *some* alt text.
-            // This keeps remediation robust even when we can't reliably match content-stream occurrences to tag-tree elements.
-            var fallbackImageAltSet = 0;
+            // Clean up objectively broken structure, but do not hide unresolved figures behind placeholder alt text.
+            // Remaining /Figure nodes without /Alt should still be visible to accessibility QA/manual remediation.
+            var remainingFiguresMissingAlt = 0;
             var contentlessFiguresRemoved = 0;
             var contentlessFiguresDemoted = 0;
             foreach (var figure in PdfStructTreeIndex.ListStructElementsByRole(pdf, PdfName.Figure))
@@ -714,14 +746,13 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                 if (!HasNonEmptyAlt(figure))
                 {
-                    SetAlt(figure, _altTextService.GetFallbackAltTextForImage());
-                    fallbackImageAltSet++;
+                    remainingFiguresMissingAlt++;
                 }
             }
 
             if (_options.GenerateLinkAltText)
             {
-                var fallbackLinkAltSet = 0;
+                var remainingLinksMissingAlt = 0;
                 var contentlessLinksRemoved = 0;
                 var contentlessLinksDemoted = 0;
                 foreach (var link in PdfStructTreeIndex.ListStructElementsByRole(pdf, PdfName.Link))
@@ -744,27 +775,28 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                     if (!HasNonEmptyAlt(link))
                     {
-                        SetAlt(link, _altTextService.GetFallbackAltTextForLink());
-                        fallbackLinkAltSet++;
+                        remainingLinksMissingAlt++;
                     }
                 }
 
                 _logger.LogInformation(
-                    "PDF remediation link alt summary: {fileId} linkOccurrences={linkOccurrences} linkAltSet={linkAltSet} fallbackLinkAltSet={fallbackLinkAltSet} contentlessLinksRemoved={contentlessLinksRemoved} contentlessLinksDemoted={contentlessLinksDemoted}",
+                    "PDF remediation link alt summary: {fileId} linkOccurrences={linkOccurrences} linkAltSet={linkAltSet} remainingLinksMissingAlt={remainingLinksMissingAlt} contentlessLinksRemoved={contentlessLinksRemoved} contentlessLinksDemoted={contentlessLinksDemoted}",
                     fileId,
                     linkOccurrences,
                     linkAltSet,
-                    fallbackLinkAltSet,
+                    remainingLinksMissingAlt,
                     contentlessLinksRemoved,
                     contentlessLinksDemoted);
             }
 
             _logger.LogInformation(
-                "PDF remediation image alt summary: {fileId} imageOccurrences={imageOccurrences} imageAltSet={imageAltSet} fallbackImageAltSet={fallbackImageAltSet} contentlessFiguresRemoved={contentlessFiguresRemoved} contentlessFiguresDemoted={contentlessFiguresDemoted}",
+                "PDF remediation image alt summary: {fileId} imageOccurrences={imageOccurrences} imageAltSet={imageAltSet} imageAltSkippedUnsupported={imageAltSkippedUnsupported} imageAltFailures={imageAltFailures} remainingFiguresMissingAlt={remainingFiguresMissingAlt} contentlessFiguresRemoved={contentlessFiguresRemoved} contentlessFiguresDemoted={contentlessFiguresDemoted}",
                 fileId,
                 imageOccurrences,
                 imageAltSet,
-                fallbackImageAltSet,
+                imageAltSkippedUnsupported,
+                imageAltFailures,
+                remainingFiguresMissingAlt,
                 contentlessFiguresRemoved,
                 contentlessFiguresDemoted);
 
@@ -1089,6 +1121,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
         return null;
     }
+
+    private static bool IsSupportedAltTextImageMimeType(string mimeType) =>
+        string.Equals(mimeType, "image/png", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(mimeType, "image/jpeg", StringComparison.OrdinalIgnoreCase);
 
     private static bool LooksLikePng(byte[] bytes) =>
         bytes.Length >= 8

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -353,6 +353,12 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
             var decorativeFigureAltSkipped = 0;
             var decorativeFigures = new PdfDecorativeFigureTracker(fileId, _logger, TryRemoveStructElemFromParent);
 
+            int CountDecorativeChanges(Func<bool> removeOrDemote)
+            {
+                var before = decorativeFigures.Total;
+                return removeOrDemote() ? decorativeFigures.Total - before : 0;
+            }
+
             foreach (var figure in PdfStructTreeIndex.ListStructElementsByRole(pdf, PdfName.Figure))
             {
                 if (StructElemHasAssociatedContent(figure))
@@ -360,9 +366,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     continue;
                 }
 
-                if (decorativeFigures.RemoveOrDemote(figure, "figure has no associated content"))
+                var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(figure, "figure has no associated content"));
+                if (changeCount > 0)
                 {
-                    decorativeFigureAltSkipped++;
+                    decorativeFigureAltSkipped += changeCount;
                 }
             }
 
@@ -404,9 +411,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         if (occ.Bounds is not null
                             && PdfFigureVisualHeuristics.IsTinyFigureBounds(occ.Bounds, page.GetPageSizeWithRotation(), out var tinyReason))
                         {
-                            if (decorativeFigures.RemoveOrDemote(figure, tinyReason, pageNumber))
+                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(figure, tinyReason, pageNumber));
+                            if (changeCount > 0)
                             {
-                                decorativeFigureAltSkipped++;
+                                decorativeFigureAltSkipped += changeCount;
                             }
 
                             continue;
@@ -416,9 +424,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         if (!IsSupportedAltTextImageMimeType(mimeType))
                         {
                             imageAltSkippedUnsupported++;
-                            if (decorativeFigures.RemoveOrDemote(figure, $"unsupported image MIME type {mimeType}", pageNumber))
+                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(figure, $"unsupported image MIME type {mimeType}", pageNumber));
+                            if (changeCount > 0)
                             {
-                                decorativeFigureAltSkipped++;
+                                decorativeFigureAltSkipped += changeCount;
                             }
 
                             continue;
@@ -428,15 +437,19 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         {
                             var imageHash = Convert.ToHexString(SHA256.HashData(bytes));
                             var repeatedSignature = PdfFigureVisualHeuristics.BuildRepeatedChromeSignature(imageHash, occ.Bounds, page.GetPageSizeWithRotation());
-                            if (repeatedSignature is not null
-                                && decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
-                                    figure,
-                                    repeatedSignature,
-                                    "same image appears repeatedly in the same page position",
-                                    pageNumber))
+                            if (repeatedSignature is not null)
                             {
-                                decorativeFigureAltSkipped++;
-                                continue;
+                                var changeCount = CountDecorativeChanges(
+                                    () => decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
+                                        figure,
+                                        repeatedSignature,
+                                        "same image appears repeatedly in the same page position",
+                                        pageNumber));
+                                if (changeCount > 0)
+                                {
+                                    decorativeFigureAltSkipped += changeCount;
+                                    continue;
+                                }
                             }
                         }
 
@@ -671,9 +684,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                                         if (PdfFigureVisualHeuristics.IsTinyFigureBounds(candidate.BoundsPts, pageSizePts, out var tinyReason))
                                         {
-                                            if (decorativeFigures.RemoveOrDemote(candidate.Figure, tinyReason, pageNumber))
+                                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(candidate.Figure, tinyReason, pageNumber));
+                                            if (changeCount > 0)
                                             {
-                                                decorativeFigureAltSkipped++;
+                                                decorativeFigureAltSkipped += changeCount;
                                             }
 
                                             continue;
@@ -705,9 +719,10 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                                         if (PdfFigureVisualHeuristics.TryClassifyLowInformationBitmap(cropBitmap, out var lowInformationReason))
                                         {
-                                            if (decorativeFigures.RemoveOrDemote(candidate.Figure, lowInformationReason, pageNumber))
+                                            var changeCount = CountDecorativeChanges(() => decorativeFigures.RemoveOrDemote(candidate.Figure, lowInformationReason, pageNumber));
+                                            if (changeCount > 0)
                                             {
-                                                decorativeFigureAltSkipped++;
+                                                decorativeFigureAltSkipped += changeCount;
                                             }
 
                                             continue;
@@ -715,15 +730,19 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                                         var bitmapHash = PdfFigureVisualHeuristics.ComputeBitmapHash(cropBitmap);
                                         var repeatedSignature = PdfFigureVisualHeuristics.BuildRepeatedChromeSignature(bitmapHash, candidate.BoundsPts, pageSizePts);
-                                        if (repeatedSignature is not null
-                                            && decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
-                                                candidate.Figure,
-                                                repeatedSignature,
-                                                "same visual crop appears repeatedly in the same page position",
-                                                pageNumber))
+                                        if (repeatedSignature is not null)
                                         {
-                                            decorativeFigureAltSkipped++;
-                                            continue;
+                                            var changeCount = CountDecorativeChanges(
+                                                () => decorativeFigures.RemoveOrDemoteRepeatedChromeFigure(
+                                                    candidate.Figure,
+                                                    repeatedSignature,
+                                                    "same visual crop appears repeatedly in the same page position",
+                                                    pageNumber));
+                                            if (changeCount > 0)
+                                            {
+                                                decorativeFigureAltSkipped += changeCount;
+                                                continue;
+                                            }
                                         }
 
                                         byte[] pngBytes;

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorDecorativeFigureTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorDecorativeFigureTests.cs
@@ -10,28 +10,18 @@ using server.core.Remediate.Rasterize;
 
 namespace server.tests.Integration.Remediate;
 
-public sealed class PdfRemediationProcessorVectorFigureAltTests
+public sealed class PdfRemediationProcessorDecorativeFigureTests
 {
     [Fact]
-    public async Task ProcessAsync_TaggedHasPlaceholderAlt_ReplacesPlaceholderAltForVectorFigures()
+    public async Task ProcessAsync_TinyVectorFigure_DemotesWithoutCallingAltTextService()
     {
-        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-vector-alt-{Guid.NewGuid():N}");
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-vector-tiny-{Guid.NewGuid():N}");
         Directory.CreateDirectory(runRoot);
 
         try
         {
             var inputPdfPath = Path.Combine(runRoot, "input.pdf");
-            CreateTaggedPdfWithPlaceholderVectorFigure(inputPdfPath);
-
-            var inputPlaceholderCount = 0;
-            using (var inputPdf = new PdfDocument(new PdfReader(inputPdfPath)))
-            {
-                inputPdf.IsTagged().Should().BeTrue("fixture should be tagged");
-                var inputFigures = ListStructElementsByRole(inputPdf, PdfName.Figure);
-                inputFigures.Count.Should().BeGreaterThan(0);
-                inputPlaceholderCount = inputFigures.Count(f => IsPlaceholderAlt(f));
-                inputPlaceholderCount.Should().BeGreaterThan(0, "fixture should contain placeholder alt text");
-            }
+            CreateTaggedPdfWithPlaceholderVectorFigure(inputPdfPath, figureWidth: 4, figureHeight: 4);
 
             var outputPdfPath = Path.Combine(runRoot, "output.pdf");
 
@@ -40,7 +30,7 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
                 altText,
                 new NoopPdfBookmarkService(),
                 new FakePdfTitleService(),
-                new FakePdfPageRasterizer(),
+                new DetailPdfPageRasterizer(),
                 NullLogger<PdfRemediationProcessor>.Instance);
 
             await sut.ProcessAsync(
@@ -51,10 +41,9 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
 
             using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
             var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
-            var outputPlaceholderCount = outputFigures.Count(f => IsPlaceholderAlt(f));
 
-            outputPlaceholderCount.Should().BeLessThan(inputPlaceholderCount, "vector figure remediation should reduce placeholder alt text");
-            altText.ImageCalls.Should().BeGreaterThan(0, "vector figure remediation should call the alt text service at least once");
+            outputFigures.Should().BeEmpty("tiny figure artifacts should be removed or demoted before AI alt text");
+            altText.ImageCalls.Should().Be(0);
         }
         finally
         {
@@ -65,7 +54,52 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
         }
     }
 
-    private static void CreateTaggedPdfWithPlaceholderVectorFigure(string outputPath)
+    [Fact]
+    public async Task ProcessAsync_BlankVectorFigureCrop_DemotesWithoutCallingAltTextService()
+    {
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-vector-blank-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTaggedPdfWithPlaceholderVectorFigure(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+
+            var altText = new FakeAltTextService();
+            var sut = new PdfRemediationProcessor(
+                altText,
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                new BlankPdfPageRasterizer(),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
+
+            outputFigures.Should().BeEmpty("blank figure crops should be removed or demoted before AI alt text");
+            altText.ImageCalls.Should().Be(0);
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    private static void CreateTaggedPdfWithPlaceholderVectorFigure(
+        string outputPath,
+        float figureWidth = 120,
+        float figureHeight = 80)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
 
@@ -125,7 +159,7 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
         canvas.BeginMarkedContent(PdfName.Figure, markedContentProperties);
         canvas.SaveState();
         canvas.SetFillColor(ColorConstants.BLACK);
-        canvas.Rectangle(100, 500, 120, 80);
+        canvas.Rectangle(100, 500, figureWidth, figureHeight);
         canvas.Fill();
         canvas.RestoreState();
         canvas.EndMarkedContent();
@@ -166,7 +200,7 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
         }
     }
 
-    private sealed class FakePdfPageRasterizer : IPdfPageRasterizer
+    private sealed class DetailPdfPageRasterizer : IPdfPageRasterizer
     {
         private static readonly BgraBitmap PageWithVisualDetail = CreatePageWithVisualDetail(widthPx: 200, heightPx: 200);
 
@@ -214,10 +248,47 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
         }
     }
 
-    private static bool IsPlaceholderAlt(PdfDictionary structElem)
+    private sealed class BlankPdfPageRasterizer : IPdfPageRasterizer
     {
-        var alt = structElem.GetAsString(PdfName.Alt)?.ToUnicodeString() ?? string.Empty;
-        return string.Equals(alt.Trim(), "alt text for image", StringComparison.OrdinalIgnoreCase);
+        private static readonly BgraBitmap BlankPage = CreateBlankPage(widthPx: 200, heightPx: 200);
+
+        public bool IsAvailable => true;
+
+        public IPdfRasterDocument OpenDocument(string pdfPath, int dpi)
+        {
+            _ = pdfPath;
+            _ = dpi;
+            return new Doc();
+        }
+
+        private sealed class Doc : IPdfRasterDocument
+        {
+            public void Dispose()
+            {
+            }
+
+            public BgraBitmap RenderPage(int pageNumber1Based, CancellationToken cancellationToken)
+            {
+                _ = pageNumber1Based;
+                cancellationToken.ThrowIfCancellationRequested();
+                return BlankPage;
+            }
+        }
+
+        private static BgraBitmap CreateBlankPage(int widthPx, int heightPx)
+        {
+            var stride = widthPx * 4;
+            var bytes = new byte[stride * heightPx];
+            for (var i = 0; i < bytes.Length; i += 4)
+            {
+                bytes[i + 0] = 255; // B
+                bytes[i + 1] = 255; // G
+                bytes[i + 2] = 255; // R
+                bytes[i + 3] = 255; // A
+            }
+
+            return new BgraBitmap(bytes, widthPx, heightPx, stride);
+        }
     }
 
     private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorImageExtractionTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorImageExtractionTests.cs
@@ -102,6 +102,46 @@ public sealed class PdfRemediationProcessorImageExtractionTests
         }
     }
 
+    [Fact]
+    public async Task ProcessAsync_WhenRasterImageAltGenerationFails_LeavesFigureWithoutAlt()
+    {
+        var repoRoot = FindRepoRoot();
+        var inputPdfPath = Path.Combine(repoRoot, "tests", "server.tests", "Fixtures", "pdfs", "tagged-missing-alt.pdf");
+        File.Exists(inputPdfPath).Should().BeTrue($"fixture should exist at {inputPdfPath}");
+
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-alt-fail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            var result = await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(result.OutputPdfPath));
+            var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
+            outputFigures.Count.Should().BeGreaterThan(0);
+            outputFigures.Any(f => !HasNonEmptyAlt(f)).Should().BeTrue("failed automation should leave figures for manual remediation instead of writing placeholder alt");
+            outputFigures.Should().NotContain(f => GetAlt(f) == "fake image alt text");
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
     private sealed class CapturingAltTextService : IAltTextService
     {
         public List<ImageAltTextRequest> ImageRequests { get; } = new();
@@ -119,6 +159,27 @@ public sealed class PdfRemediationProcessorImageExtractionTests
             cancellationToken.ThrowIfCancellationRequested();
             LinkRequests.Add(request);
             return Task.FromResult("fake link alt text");
+        }
+
+        public string GetFallbackAltTextForImage() => "fake image alt text";
+
+        public string GetFallbackAltTextForLink() => "fake link alt text";
+    }
+
+    private sealed class ThrowingAltTextService : IAltTextService
+    {
+        public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("fake alt text failure");
+        }
+
+        public Task<string> GetAltTextForLinkAsync(LinkAltTextRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("fake link alt text failure");
         }
 
         public string GetFallbackAltTextForImage() => "fake image alt text";
@@ -151,4 +212,68 @@ public sealed class PdfRemediationProcessorImageExtractionTests
 
         return dir.FullName;
     }
+
+    private static bool HasNonEmptyAlt(PdfDictionary structElem)
+    {
+        var alt = GetAlt(structElem);
+        return !string.IsNullOrWhiteSpace(alt);
+    }
+
+    private static string? GetAlt(PdfDictionary structElem) => structElem.GetAsString(PdfName.Alt)?.ToUnicodeString();
+
+    private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
+    {
+        var results = new List<PdfDictionary>();
+
+        var catalogDict = pdf.GetCatalog().GetPdfObject();
+        var structTreeRootDict = catalogDict.GetAsDictionary(PdfName.StructTreeRoot);
+        if (structTreeRootDict is null)
+        {
+            return results;
+        }
+
+        var rootKids = structTreeRootDict.Get(PdfName.K);
+        if (rootKids is null)
+        {
+            return results;
+        }
+
+        Traverse(rootKids, role, results);
+        return results;
+    }
+
+    private static void Traverse(PdfObject node, PdfName role, List<PdfDictionary> results)
+    {
+        node = Dereference(node);
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                Traverse(item, role, results);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        var s = dict.GetAsName(PdfName.S);
+        if (role.Equals(s))
+        {
+            results.Add(dict);
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            Traverse(kids, role, results);
+        }
+    }
+
+    private static PdfObject Dereference(PdfObject obj)
+        => obj is PdfIndirectReference reference ? reference.GetRefersTo(true) : obj;
 }

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTests.cs
@@ -23,17 +23,17 @@ public sealed class PdfRemediationProcessorTests
             inputFigures.Any(f => !HasNonEmptyAlt(f)).Should().BeTrue("fixture should have figures missing alt text");
         }
 
-            var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(runRoot);
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
 
-            try
-            {
-                var outputPdfPath = Path.Combine(runRoot, "output.pdf");
-                var sut = new PdfRemediationProcessor(
-                    new FakeAltTextService(),
-                    new NoopPdfBookmarkService(),
-                    new FakePdfTitleService(),
-                    NullLogger<PdfRemediationProcessor>.Instance);
+        try
+        {
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var sut = new PdfRemediationProcessor(
+                new FakeAltTextService(),
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                NullLogger<PdfRemediationProcessor>.Instance);
 
             var result = await sut.ProcessAsync(
                 fileId: "fixture",
@@ -59,46 +59,6 @@ public sealed class PdfRemediationProcessorTests
         }
     }
 
-    [Fact]
-    public async Task ProcessAsync_WhenRasterImageAltGenerationFails_LeavesFigureWithoutAlt()
-    {
-        var repoRoot = FindRepoRoot();
-        var inputPdfPath = Path.Combine(repoRoot, "tests", "server.tests", "Fixtures", "pdfs", "tagged-missing-alt.pdf");
-        File.Exists(inputPdfPath).Should().BeTrue($"fixture should exist at {inputPdfPath}");
-
-        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-alt-fail-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(runRoot);
-
-        try
-        {
-            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
-            var sut = new PdfRemediationProcessor(
-                new ThrowingAltTextService(),
-                new NoopPdfBookmarkService(),
-                new FakePdfTitleService(),
-                NullLogger<PdfRemediationProcessor>.Instance);
-
-            var result = await sut.ProcessAsync(
-                fileId: "fixture",
-                inputPdfPath: inputPdfPath,
-                outputPdfPath: outputPdfPath,
-                cancellationToken: CancellationToken.None);
-
-            using var outputPdf = new PdfDocument(new PdfReader(result.OutputPdfPath));
-            var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
-            outputFigures.Count.Should().BeGreaterThan(0);
-            outputFigures.Any(f => !HasNonEmptyAlt(f)).Should().BeTrue("failed automation should leave figures for manual remediation instead of writing placeholder alt");
-            outputFigures.Should().NotContain(f => GetAlt(f) == "fake image alt text");
-        }
-        finally
-        {
-            if (Directory.Exists(runRoot))
-            {
-                Directory.Delete(runRoot, recursive: true);
-            }
-        }
-    }
-
     private sealed class FakeAltTextService : IAltTextService
     {
         public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken)
@@ -113,27 +73,6 @@ public sealed class PdfRemediationProcessorTests
             _ = request;
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult("fake link alt text");
-        }
-
-        public string GetFallbackAltTextForImage() => "fake image alt text";
-
-        public string GetFallbackAltTextForLink() => "fake link alt text";
-    }
-
-    private sealed class ThrowingAltTextService : IAltTextService
-    {
-        public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken)
-        {
-            _ = request;
-            cancellationToken.ThrowIfCancellationRequested();
-            throw new InvalidOperationException("fake alt text failure");
-        }
-
-        public Task<string> GetAltTextForLinkAsync(LinkAltTextRequest request, CancellationToken cancellationToken)
-        {
-            _ = request;
-            cancellationToken.ThrowIfCancellationRequested();
-            throw new InvalidOperationException("fake link alt text failure");
         }
 
         public string GetFallbackAltTextForImage() => "fake image alt text";

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorTests.cs
@@ -9,7 +9,7 @@ namespace server.tests.Integration.Remediate;
 public sealed class PdfRemediationProcessorTests
 {
     [Fact]
-    public async Task ProcessAsync_TaggedMissingAlt_AddsAltToFigures()
+    public async Task ProcessAsync_TaggedMissingAlt_AddsAltToMatchedFigures()
     {
         var repoRoot = FindRepoRoot();
         var inputPdfPath = Path.Combine(repoRoot, "tests", "server.tests", "Fixtures", "pdfs", "tagged-missing-alt.pdf");
@@ -48,8 +48,47 @@ public sealed class PdfRemediationProcessorTests
 
             var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
             outputFigures.Count.Should().BeGreaterThan(0);
-            outputFigures.Should().OnlyContain(f => HasNonEmptyAlt(f));
             outputFigures.Any(f => GetAlt(f) == "fake image alt text").Should().BeTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenRasterImageAltGenerationFails_LeavesFigureWithoutAlt()
+    {
+        var repoRoot = FindRepoRoot();
+        var inputPdfPath = Path.Combine(repoRoot, "tests", "server.tests", "Fixtures", "pdfs", "tagged-missing-alt.pdf");
+        File.Exists(inputPdfPath).Should().BeTrue($"fixture should exist at {inputPdfPath}");
+
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-alt-fail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            var result = await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(result.OutputPdfPath));
+            var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
+            outputFigures.Count.Should().BeGreaterThan(0);
+            outputFigures.Any(f => !HasNonEmptyAlt(f)).Should().BeTrue("failed automation should leave figures for manual remediation instead of writing placeholder alt");
+            outputFigures.Should().NotContain(f => GetAlt(f) == "fake image alt text");
         }
         finally
         {
@@ -74,6 +113,27 @@ public sealed class PdfRemediationProcessorTests
             _ = request;
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult("fake link alt text");
+        }
+
+        public string GetFallbackAltTextForImage() => "fake image alt text";
+
+        public string GetFallbackAltTextForLink() => "fake link alt text";
+    }
+
+    private sealed class ThrowingAltTextService : IAltTextService
+    {
+        public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("fake alt text failure");
+        }
+
+        public Task<string> GetAltTextForLinkAsync(LinkAltTextRequest request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("fake link alt text failure");
         }
 
         public string GetFallbackAltTextForImage() => "fake image alt text";

--- a/workers/function.ingest/host.json
+++ b/workers/function.ingest/host.json
@@ -16,5 +16,10 @@
         "console": {
             "isEnabled": true
         }
+    },
+    "extensions": {
+        "serviceBus": {
+            "maxAutoLockRenewalDuration": "00:35:00"
+        }
     }
 }


### PR DESCRIPTION
Enhances PDF remediation by intelligently identifying and handling decorative figures, reducing unnecessary AI processing, and improving the quality of alt text.

*   **Automated Decorative Figure Handling:** Implements new heuristics to classify figures as decorative based on visual characteristics such as tiny size, low information content, or repetition as "chrome". These figures are then either removed from the PDF structure tree or demoted to `Span` elements, preventing them from being announced by screen readers and optimizing downstream AI alt-text generation.
*   **Improved Alt Text Generation Failure Handling:** When AI-driven alt text generation fails, figures now remain without alt text, rather than being assigned generic fallback text. This ensures that figures requiring manual remediation are clearly identifiable.
*   **Enhanced Metrics and Logging:** Introduces comprehensive tracking and logging for figures that are removed, demoted, or skipped due to various criteria or processing failures, providing a clearer audit trail of remediation outcomes.
*   **Queue Durability:** Extends the Service Bus message auto-lock renewal duration to accommodate longer-running PDF remediation tasks, preventing message expiration during extensive processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced PDF figure remediation to automatically identify and handle decorative elements, including intelligent detection of tiny figures, low-information bitmaps, and repeated decorative patterns across documents.

* **Bug Fixes**
  * Improved error handling and robustness during alt text generation with graceful fallbacks for unsupported image formats.

* **Tests**
  * Added integration tests validating decorative figure detection and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->