### PR TITLE
Implement distributed rate limiting for APIs

### DIFF
--- a/server.core/Data/AppDbContext.cs
+++ b/server.core/Data/AppDbContext.cs
@@ -12,6 +12,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<FileRecord> Files => Set<FileRecord>();
     public DbSet<FileProcessingAttempt> FileProcessingAttempts => Set<FileProcessingAttempt>();
     public DbSet<AccessibilityReport> AccessibilityReports => Set<AccessibilityReport>();
+    public DbSet<ExternalApiRateLimitBucket> ExternalApiRateLimitBuckets => Set<ExternalApiRateLimitBucket>();
+    public DbSet<ExternalApiRateLimitReservation> ExternalApiRateLimitReservations => Set<ExternalApiRateLimitReservation>();
 
     public DbSet<WeatherForecast> WeatherForecasts => Set<WeatherForecast>();
 
@@ -25,6 +27,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         FileRecord.OnModelCreating(modelBuilder);
         FileProcessingAttempt.OnModelCreating(modelBuilder);
         AccessibilityReport.OnModelCreating(modelBuilder);
+        ExternalApiRateLimitBucket.OnModelCreating(modelBuilder);
+        ExternalApiRateLimitReservation.OnModelCreating(modelBuilder);
         ApiKey.OnModelCreating(modelBuilder);
 
         base.OnModelCreating(modelBuilder);

--- a/server.core/Domain/ExternalApiRateLimitBucket.cs
+++ b/server.core/Domain/ExternalApiRateLimitBucket.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace server.core.Domain;
+
+public class ExternalApiRateLimitBucket
+{
+    [StringLength(64)]
+    public string Provider { get; set; } = string.Empty;
+
+    [StringLength(64)]
+    public string Operation { get; set; } = string.Empty;
+
+    [StringLength(128)]
+    public string BucketKey { get; set; } = string.Empty;
+
+    public DateTimeOffset? PausedUntilUtc { get; set; }
+
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+
+    internal static void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ExternalApiRateLimitBucket>(entity =>
+        {
+            entity.ToTable("ExternalApiRateLimitBuckets");
+            entity.HasKey(x => new { x.Provider, x.Operation, x.BucketKey });
+
+            entity.Property(x => x.Provider)
+                .HasMaxLength(64)
+                .IsRequired();
+
+            entity.Property(x => x.Operation)
+                .HasMaxLength(64)
+                .IsRequired();
+
+            entity.Property(x => x.BucketKey)
+                .HasMaxLength(128)
+                .IsRequired();
+
+            entity.HasIndex(x => x.PausedUntilUtc);
+        });
+    }
+}

--- a/server.core/Domain/ExternalApiRateLimitReservation.cs
+++ b/server.core/Domain/ExternalApiRateLimitReservation.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace server.core.Domain;
+
+public class ExternalApiRateLimitReservation
+{
+    public long ReservationId { get; set; }
+
+    [StringLength(64)]
+    public string Provider { get; set; } = string.Empty;
+
+    [StringLength(64)]
+    public string Operation { get; set; } = string.Empty;
+
+    [StringLength(128)]
+    public string BucketKey { get; set; } = string.Empty;
+
+    [StringLength(64)]
+    public string RequestId { get; set; } = string.Empty;
+
+    public int Cost { get; set; }
+
+    public DateTimeOffset ReservedAtUtc { get; set; }
+
+    public DateTimeOffset ExpiresAtUtc { get; set; }
+
+    internal static void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ExternalApiRateLimitReservation>(entity =>
+        {
+            entity.ToTable(
+                "ExternalApiRateLimitReservations",
+                table => table.HasCheckConstraint("CK_ExternalApiRateLimitReservations_Cost", "[Cost] > 0"));
+            entity.HasKey(x => x.ReservationId);
+
+            entity.Property(x => x.Provider)
+                .HasMaxLength(64)
+                .IsRequired();
+
+            entity.Property(x => x.Operation)
+                .HasMaxLength(64)
+                .IsRequired();
+
+            entity.Property(x => x.BucketKey)
+                .HasMaxLength(128)
+                .IsRequired();
+
+            entity.Property(x => x.RequestId)
+                .HasMaxLength(64)
+                .IsRequired();
+
+            entity.HasIndex(x => x.RequestId)
+                .IsUnique();
+
+            entity.HasIndex(x => new { x.Provider, x.Operation, x.BucketKey, x.ExpiresAtUtc });
+        });
+    }
+}

--- a/server.core/Ingest/AdobePdfServices.cs
+++ b/server.core/Ingest/AdobePdfServices.cs
@@ -77,6 +77,10 @@ public sealed class AdobePdfServices : IAdobePdfServices
         var pdfServices = CreateClient();
 
         await using var inputStream = File.OpenRead(inputPdfPath);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.Autotag,
+            "upload",
+            cancellationToken);
         IAsset asset = pdfServices.Upload(inputStream, PDFServicesMediaType.PDF.GetMIMETypeValue());
 
         AutotagPDFParams autotagParams = AutotagPDFParams
@@ -85,17 +89,33 @@ public sealed class AdobePdfServices : IAdobePdfServices
             .Build();
 
         AutotagPDFJob job = new AutotagPDFJob(asset).SetParams(autotagParams);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.Autotag,
+            "submit",
+            cancellationToken);
         var location = pdfServices.Submit(job);
 
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.Autotag,
+            "get_job_result",
+            cancellationToken);
         PDFServicesResponse<AutotagPDFResult> response =
             pdfServices.GetJobResult<AutotagPDFResult>(location, typeof(AutotagPDFResult));
 
         var taggedAsset = response.Result.TaggedPDF;
         var reportAsset = response.Result.Report;
 
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.Autotag,
+            "get_tagged_content",
+            cancellationToken);
         var taggedStreamAsset = pdfServices.GetContent(taggedAsset);
         await WriteStreamAssetAsync(taggedStreamAsset, outputTaggedPdfPath, cancellationToken);
 
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.Autotag,
+            "get_report_content",
+            cancellationToken);
         var reportStreamAsset = pdfServices.GetContent(reportAsset);
         await WriteStreamAssetAsync(reportStreamAsset, outputTaggingReportPath, cancellationToken);
 
@@ -178,7 +198,10 @@ public sealed class AdobePdfServices : IAdobePdfServices
         var pdfServices = CreateClient();
 
         await using var inputStream = File.OpenRead(inputPdfPath);
-        await WaitForAccessibilityCheckerCallAsync("upload", cancellationToken);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            "upload",
+            cancellationToken);
         IAsset asset = pdfServices.Upload(inputStream, PDFServicesMediaType.PDF.GetMIMETypeValue());
 
         var job = new PDFAccessibilityCheckerJob(asset);
@@ -198,7 +221,10 @@ public sealed class AdobePdfServices : IAdobePdfServices
             job = job.SetParams(builder.Build());
         }
 
-        await WaitForAccessibilityCheckerCallAsync("submit", cancellationToken);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            "submit",
+            cancellationToken);
         var location = pdfServices.Submit(job);
         PDFServicesResponse<PDFAccessibilityCheckerResult> response =
             await GetAccessibilityCheckerResultAsync(pdfServices, location, cancellationToken);
@@ -206,11 +232,17 @@ public sealed class AdobePdfServices : IAdobePdfServices
         var outputAsset = response.Result.Asset;
         var reportAsset = response.Result.Report;
 
-        await WaitForAccessibilityCheckerCallAsync("get_output_content", cancellationToken);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            "get_output_content",
+            cancellationToken);
         var outputStreamAsset = pdfServices.GetContent(outputAsset);
         await WriteStreamAssetAsync(outputStreamAsset, outputPdfPath, cancellationToken);
 
-        await WaitForAccessibilityCheckerCallAsync("get_report_content", cancellationToken);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            "get_report_content",
+            cancellationToken);
         var reportStreamAsset = pdfServices.GetContent(reportAsset);
         await WriteStreamAssetAsync(reportStreamAsset, outputReportPath, cancellationToken);
 
@@ -250,7 +282,10 @@ public sealed class AdobePdfServices : IAdobePdfServices
                     $"location={location}; lastStatus={lastStatus ?? "unknown"}; attempts={attempts}; elapsedMs={stopwatch.ElapsedMilliseconds}");
             }
 
-            await WaitForAccessibilityCheckerCallAsync("get_job_status", cancellationToken);
+            await WaitForAdobePdfServicesCallAsync(
+                AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+                "get_job_status",
+                cancellationToken);
             var statusResponse = pdfServices.GetJobStatus(location);
             attempts++;
             var status = statusResponse.Status;
@@ -270,7 +305,10 @@ public sealed class AdobePdfServices : IAdobePdfServices
             await Task.Delay(TimeSpan.FromSeconds(retryIntervalSeconds), cancellationToken);
         }
 
-        await WaitForAccessibilityCheckerCallAsync("get_job_result", cancellationToken);
+        await WaitForAdobePdfServicesCallAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            "get_job_result",
+            cancellationToken);
         return pdfServices.GetJobResult<PDFAccessibilityCheckerResult>(
             location,
             typeof(PDFAccessibilityCheckerResult));
@@ -297,16 +335,19 @@ public sealed class AdobePdfServices : IAdobePdfServices
         }
     }
 
-    private async Task WaitForAccessibilityCheckerCallAsync(string callName, CancellationToken cancellationToken)
+    private async Task WaitForAdobePdfServicesCallAsync(
+        string operation,
+        string callName,
+        CancellationToken cancellationToken)
     {
         using var scope = _logger.BeginScope(new Dictionary<string, object?>
         {
-            ["adobe.pdf_services.operation"] = AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            ["adobe.pdf_services.operation"] = operation,
             ["adobe.pdf_services.call"] = callName,
         });
 
         await _rateLimiter.WaitAsync(
-            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            operation,
             cost: 1,
             cancellationToken);
     }

--- a/server.core/Ingest/AdobePdfServices.cs
+++ b/server.core/Ingest/AdobePdfServices.cs
@@ -5,6 +5,7 @@ using Adobe.PDFServicesSDK.pdfjobs.jobs;
 using Adobe.PDFServicesSDK.pdfjobs.parameters.autotag;
 using Adobe.PDFServicesSDK.pdfjobs.parameters.pdfaccessibilitychecker;
 using Adobe.PDFServicesSDK.pdfjobs.results;
+using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -234,12 +235,26 @@ public sealed class AdobePdfServices : IAdobePdfServices
         string location,
         CancellationToken cancellationToken)
     {
+        var maxPollDuration = GetAccessibilityCheckerMaxPollDuration();
+        var stopwatch = Stopwatch.StartNew();
+        var attempts = 0;
+        string? lastStatus = null;
+
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (stopwatch.Elapsed >= maxPollDuration)
+            {
+                throw new TimeoutException(
+                    $"Adobe Accessibility Checker job polling exceeded {maxPollDuration.TotalSeconds:N0}s. " +
+                    $"location={location}; lastStatus={lastStatus ?? "unknown"}; attempts={attempts}; elapsedMs={stopwatch.ElapsedMilliseconds}");
+            }
+
             await WaitForAccessibilityCheckerCallAsync("get_job_status", cancellationToken);
             var statusResponse = pdfServices.GetJobStatus(location);
+            attempts++;
             var status = statusResponse.Status;
+            lastStatus = status;
             if (string.Equals(status, "DONE", StringComparison.OrdinalIgnoreCase))
             {
                 break;
@@ -248,7 +263,7 @@ public sealed class AdobePdfServices : IAdobePdfServices
             if (string.Equals(status, "FAILED", StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException(
-                    $"Adobe Accessibility Checker job failed while polling status. status={status}");
+                    $"Adobe Accessibility Checker job failed while polling status. location={location}; status={status}; attempts={attempts}");
             }
 
             var retryIntervalSeconds = Math.Max(1, statusResponse.GetRetryInterval());
@@ -324,6 +339,16 @@ public sealed class AdobePdfServices : IAdobePdfServices
             ?? _configuration.GetValue<double?>("ADOBE_ACCESSIBILITY_CHECKER_RETRY_MAX_DELAY_SECONDS");
 
         return TimeSpan.FromSeconds(Math.Max(0, configuredSeconds ?? 30));
+    }
+
+    private TimeSpan GetAccessibilityCheckerMaxPollDuration()
+    {
+        var configuredSeconds =
+            _configuration.GetValue<double?>("AdobePdfServices:AccessibilityCheckerMaxPollDurationSeconds")
+            ?? _configuration.GetValue<double?>("AdobePdfServices__AccessibilityCheckerMaxPollDurationSeconds")
+            ?? _configuration.GetValue<double?>("ADOBE_ACCESSIBILITY_CHECKER_MAX_POLL_DURATION_SECONDS");
+
+        return TimeSpan.FromSeconds(Math.Max(1, configuredSeconds ?? 600));
     }
 
     private static TimeSpan ComputeRetryDelay(int failedAttempt, TimeSpan baseDelay, TimeSpan maxDelay)

--- a/server.core/Ingest/AdobePdfServices.cs
+++ b/server.core/Ingest/AdobePdfServices.cs
@@ -44,14 +44,19 @@ public sealed class AdobePdfServices : IAdobePdfServices
 {
     private readonly IConfiguration _configuration;
     private readonly ILogger<AdobePdfServices> _logger;
+    private readonly IAdobePdfServicesRateLimiter _rateLimiter;
 
     public string AutotagProviderName => FileIngestOptions.AutotagProviders.Adobe;
     public string AccessibilityCheckerName => "AdobePdfServices";
 
-    public AdobePdfServices(IConfiguration configuration, ILogger<AdobePdfServices> logger)
+    public AdobePdfServices(
+        IConfiguration configuration,
+        ILogger<AdobePdfServices> logger,
+        IAdobePdfServicesRateLimiter rateLimiter)
     {
         _configuration = configuration;
         _logger = logger;
+        _rateLimiter = rateLimiter;
     }
 
     /// <summary>
@@ -136,10 +141,15 @@ public sealed class AdobePdfServices : IAdobePdfServices
             {
                 throw;
             }
-            catch (Exception ex) when (
-                attempt < maxAttempts
-                && IsRetryableAccessibilityCheckerException(ex))
+            catch (Exception ex) when (IsRetryableAccessibilityCheckerException(ex))
             {
+                await RecordAccessibilityCheckerThrottleAsync(ex, cancellationToken);
+
+                if (attempt >= maxAttempts)
+                {
+                    throw;
+                }
+
                 var delay = ComputeRetryDelay(attempt, baseDelay, maxDelay);
                 _logger.LogWarning(
                     ex,
@@ -167,6 +177,7 @@ public sealed class AdobePdfServices : IAdobePdfServices
         var pdfServices = CreateClient();
 
         await using var inputStream = File.OpenRead(inputPdfPath);
+        await WaitForAccessibilityCheckerCallAsync("upload", cancellationToken);
         IAsset asset = pdfServices.Upload(inputStream, PDFServicesMediaType.PDF.GetMIMETypeValue());
 
         var job = new PDFAccessibilityCheckerJob(asset);
@@ -186,16 +197,19 @@ public sealed class AdobePdfServices : IAdobePdfServices
             job = job.SetParams(builder.Build());
         }
 
+        await WaitForAccessibilityCheckerCallAsync("submit", cancellationToken);
         var location = pdfServices.Submit(job);
         PDFServicesResponse<PDFAccessibilityCheckerResult> response =
-            pdfServices.GetJobResult<PDFAccessibilityCheckerResult>(location, typeof(PDFAccessibilityCheckerResult));
+            await GetAccessibilityCheckerResultAsync(pdfServices, location, cancellationToken);
 
         var outputAsset = response.Result.Asset;
         var reportAsset = response.Result.Report;
 
+        await WaitForAccessibilityCheckerCallAsync("get_output_content", cancellationToken);
         var outputStreamAsset = pdfServices.GetContent(outputAsset);
         await WriteStreamAssetAsync(outputStreamAsset, outputPdfPath, cancellationToken);
 
+        await WaitForAccessibilityCheckerCallAsync("get_report_content", cancellationToken);
         var reportStreamAsset = pdfServices.GetContent(reportAsset);
         await WriteStreamAssetAsync(reportStreamAsset, outputReportPath, cancellationToken);
 
@@ -213,6 +227,73 @@ public sealed class AdobePdfServices : IAdobePdfServices
             outputReportPath);
 
         return new AdobeAccessibilityCheckOutput(outputPdfPath, outputReportPath, reportJson);
+    }
+
+    private async Task<PDFServicesResponse<PDFAccessibilityCheckerResult>> GetAccessibilityCheckerResultAsync(
+        PDFServices pdfServices,
+        string location,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await WaitForAccessibilityCheckerCallAsync("get_job_status", cancellationToken);
+            var statusResponse = pdfServices.GetJobStatus(location);
+            var status = statusResponse.Status;
+            if (string.Equals(status, "DONE", StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+
+            if (string.Equals(status, "FAILED", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Adobe Accessibility Checker job failed while polling status. status={status}");
+            }
+
+            var retryIntervalSeconds = Math.Max(1, statusResponse.GetRetryInterval());
+            await Task.Delay(TimeSpan.FromSeconds(retryIntervalSeconds), cancellationToken);
+        }
+
+        await WaitForAccessibilityCheckerCallAsync("get_job_result", cancellationToken);
+        return pdfServices.GetJobResult<PDFAccessibilityCheckerResult>(
+            location,
+            typeof(PDFAccessibilityCheckerResult));
+    }
+
+    private async Task RecordAccessibilityCheckerThrottleAsync(Exception exception, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _rateLimiter.RecordThrottleAsync(
+                AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+                exception,
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception rateLimiterException)
+        {
+            _logger.LogWarning(
+                rateLimiterException,
+                "Failed to record Adobe Accessibility Checker shared throttle cooldown.");
+        }
+    }
+
+    private async Task WaitForAccessibilityCheckerCallAsync(string callName, CancellationToken cancellationToken)
+    {
+        using var scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["adobe.pdf_services.operation"] = AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            ["adobe.pdf_services.call"] = callName,
+        });
+
+        await _rateLimiter.WaitAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            cost: 1,
+            cancellationToken);
     }
 
     private int GetAccessibilityCheckerMaxRetries()

--- a/server.core/Ingest/AdobePdfServicesRateLimiter.cs
+++ b/server.core/Ingest/AdobePdfServicesRateLimiter.cs
@@ -20,6 +20,7 @@ public interface IAdobePdfServicesRateLimiter
 
 public static class AdobePdfServicesRateLimitOperations
 {
+    public const string Autotag = "Autotag";
     public const string AccessibilityChecker = "AccessibilityChecker";
 }
 

--- a/server.core/Ingest/AdobePdfServicesRateLimiter.cs
+++ b/server.core/Ingest/AdobePdfServicesRateLimiter.cs
@@ -52,6 +52,8 @@ public sealed class SqlAdobePdfServicesRateLimiter : IAdobePdfServicesRateLimite
         _dbContextFactory = dbContextFactory;
         _options = AdobePdfServicesRateLimitOptions.FromConfiguration(configuration);
         _logger = logger;
+
+        ValidateSqlServerProviderIfEnabled();
     }
 
     public async Task WaitAsync(string operation, int cost, CancellationToken cancellationToken)
@@ -139,6 +141,26 @@ public sealed class SqlAdobePdfServicesRateLimiter : IAdobePdfServicesRateLimite
                 operation,
                 pausedUntil);
         });
+    }
+
+    private void ValidateSqlServerProviderIfEnabled()
+    {
+        if (!_options.Enabled)
+        {
+            return;
+        }
+
+        using var dbContext = _dbContextFactory.CreateDbContext();
+        if (dbContext.Database.IsSqlServer())
+        {
+            return;
+        }
+
+        var providerName = dbContext.Database.ProviderName ?? "<none>";
+        throw new InvalidOperationException(
+            "SqlAdobePdfServicesRateLimiter requires the EF Core SQL Server provider when rate limiting is enabled " +
+            "because it uses SQL Server-specific sp_getapplock and SYSUTCDATETIME(). " +
+            $"Current provider: {providerName}.");
     }
 
     private async Task<TimeSpan> TryReserveAsync(string operation, int cost, CancellationToken cancellationToken)

--- a/server.core/Ingest/AdobePdfServicesRateLimiter.cs
+++ b/server.core/Ingest/AdobePdfServicesRateLimiter.cs
@@ -142,6 +142,7 @@ public sealed class SqlAdobePdfServicesRateLimiter : IAdobePdfServicesRateLimite
 
     private async Task<TimeSpan> TryReserveAsync(string operation, int cost, CancellationToken cancellationToken)
     {
+        var requestId = Guid.NewGuid().ToString("N");
         await using var strategyContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
         var strategy = strategyContext.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
@@ -174,7 +175,7 @@ public sealed class SqlAdobePdfServicesRateLimiter : IAdobePdfServicesRateLimite
                     Provider = Provider,
                     Operation = operation,
                     BucketKey = _options.BucketKey,
-                    RequestId = Guid.NewGuid().ToString("N"),
+                    RequestId = requestId,
                     Cost = cost,
                     ReservedAtUtc = now,
                     ExpiresAtUtc = now.Add(_options.Window),

--- a/server.core/Ingest/AdobePdfServicesRateLimiter.cs
+++ b/server.core/Ingest/AdobePdfServicesRateLimiter.cs
@@ -1,0 +1,414 @@
+using System.Data;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using server.core.Data;
+using server.core.Domain;
+
+namespace server.core.Ingest;
+
+public interface IAdobePdfServicesRateLimiter
+{
+    Task WaitAsync(string operation, int cost, CancellationToken cancellationToken);
+
+    Task RecordThrottleAsync(string operation, Exception exception, CancellationToken cancellationToken);
+}
+
+public static class AdobePdfServicesRateLimitOperations
+{
+    public const string AccessibilityChecker = "AccessibilityChecker";
+}
+
+public sealed class NoopAdobePdfServicesRateLimiter : IAdobePdfServicesRateLimiter
+{
+    public Task WaitAsync(string operation, int cost, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task RecordThrottleAsync(string operation, Exception exception, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class SqlAdobePdfServicesRateLimiter : IAdobePdfServicesRateLimiter
+{
+    private const string Provider = "AdobePdfServices";
+    private readonly IDbContextFactory<AppDbContext> _dbContextFactory;
+    private readonly AdobePdfServicesRateLimitOptions _options;
+    private readonly ILogger<SqlAdobePdfServicesRateLimiter> _logger;
+
+    public SqlAdobePdfServicesRateLimiter(
+        IDbContextFactory<AppDbContext> dbContextFactory,
+        IConfiguration configuration,
+        ILogger<SqlAdobePdfServicesRateLimiter> logger)
+    {
+        _dbContextFactory = dbContextFactory;
+        _options = AdobePdfServicesRateLimitOptions.FromConfiguration(configuration);
+        _logger = logger;
+    }
+
+    public async Task WaitAsync(string operation, int cost, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || cost <= 0)
+        {
+            return;
+        }
+
+        if (cost > _options.RequestsPerWindow)
+        {
+            throw new InvalidOperationException(
+                $"Adobe PDF Services rate limit cost {cost} exceeds configured capacity {_options.RequestsPerWindow}.");
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var loggedWait = false;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var delay = await TryReserveAsync(operation, cost, cancellationToken);
+            if (delay <= TimeSpan.Zero)
+            {
+                if (stopwatch.Elapsed >= _options.WaitLogThreshold)
+                {
+                    _logger.LogInformation(
+                        "Adobe PDF Services rate limit wait completed for {operation} after {elapsedMs}ms",
+                        operation,
+                        stopwatch.Elapsed.TotalMilliseconds);
+                }
+
+                return;
+            }
+
+            if (!loggedWait && stopwatch.Elapsed + delay >= _options.WaitLogThreshold)
+            {
+                loggedWait = true;
+                _logger.LogWarning(
+                    "Adobe PDF Services rate limit delaying {operation} for {delayMs}ms; elapsedMs={elapsedMs}",
+                    operation,
+                    delay.TotalMilliseconds,
+                    stopwatch.Elapsed.TotalMilliseconds);
+            }
+
+            await Task.Delay(delay, cancellationToken);
+        }
+    }
+
+    public async Task RecordThrottleAsync(string operation, Exception exception, CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled || _options.ThrottleCooldown <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        await using var strategyContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var strategy = strategyContext.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+            await dbContext.Database.OpenConnectionAsync(cancellationToken);
+            await using var transaction = await dbContext.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+
+            await AcquireAppLockAsync(dbContext, operation, cancellationToken);
+
+            var now = await GetDatabaseUtcNowAsync(dbContext, cancellationToken);
+            var pausedUntil = now.Add(_options.ThrottleCooldown);
+            var bucket = await GetOrAddBucketAsync(dbContext, operation, now, cancellationToken);
+            if (bucket.PausedUntilUtc is null || bucket.PausedUntilUtc < pausedUntil)
+            {
+                bucket.PausedUntilUtc = pausedUntil;
+                bucket.UpdatedAtUtc = now;
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+
+            _logger.LogWarning(
+                exception,
+                "Adobe PDF Services rate limit cooldown recorded for {operation} until {pausedUntil:o}",
+                operation,
+                pausedUntil);
+        });
+    }
+
+    private async Task<TimeSpan> TryReserveAsync(string operation, int cost, CancellationToken cancellationToken)
+    {
+        await using var strategyContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var strategy = strategyContext.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+            await dbContext.Database.OpenConnectionAsync(cancellationToken);
+            await using var transaction = await dbContext.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable,
+                cancellationToken);
+
+            await AcquireAppLockAsync(dbContext, operation, cancellationToken);
+
+            var now = await GetDatabaseUtcNowAsync(dbContext, cancellationToken);
+            await DeleteExpiredReservationsAsync(dbContext, operation, now, cancellationToken);
+
+            var bucket = await GetOrAddBucketAsync(dbContext, operation, now, cancellationToken);
+            if (bucket.PausedUntilUtc is not null && bucket.PausedUntilUtc > now)
+            {
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                return bucket.PausedUntilUtc.Value - now;
+            }
+
+            var query = ActiveBucketReservations(dbContext, operation, now);
+            var used = await query.SumAsync(x => (int?)x.Cost, cancellationToken) ?? 0;
+            if (used + cost <= _options.RequestsPerWindow)
+            {
+                dbContext.ExternalApiRateLimitReservations.Add(new ExternalApiRateLimitReservation
+                {
+                    Provider = Provider,
+                    Operation = operation,
+                    BucketKey = _options.BucketKey,
+                    RequestId = Guid.NewGuid().ToString("N"),
+                    Cost = cost,
+                    ReservedAtUtc = now,
+                    ExpiresAtUtc = now.Add(_options.Window),
+                });
+                bucket.UpdatedAtUtc = now;
+
+                await dbContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                return TimeSpan.Zero;
+            }
+
+            var earliestExpiry = await query
+                .OrderBy(x => x.ExpiresAtUtc)
+                .Select(x => (DateTimeOffset?)x.ExpiresAtUtc)
+                .FirstOrDefaultAsync(cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+
+            return earliestExpiry is null || earliestExpiry <= now
+                ? TimeSpan.FromSeconds(1)
+                : earliestExpiry.Value - now;
+        });
+    }
+
+    private async Task<ExternalApiRateLimitBucket> GetOrAddBucketAsync(
+        AppDbContext dbContext,
+        string operation,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var bucket = await dbContext.ExternalApiRateLimitBuckets.SingleOrDefaultAsync(
+            x => x.Provider == Provider &&
+                 x.Operation == operation &&
+                 x.BucketKey == _options.BucketKey,
+            cancellationToken);
+
+        if (bucket is not null)
+        {
+            return bucket;
+        }
+
+        bucket = new ExternalApiRateLimitBucket
+        {
+            Provider = Provider,
+            Operation = operation,
+            BucketKey = _options.BucketKey,
+            UpdatedAtUtc = now,
+        };
+        dbContext.ExternalApiRateLimitBuckets.Add(bucket);
+        return bucket;
+    }
+
+    private IQueryable<ExternalApiRateLimitReservation> CurrentBucketReservations(
+        AppDbContext dbContext,
+        string operation)
+    {
+        return dbContext.ExternalApiRateLimitReservations
+            .Where(x => x.Provider == Provider &&
+                        x.Operation == operation &&
+                        x.BucketKey == _options.BucketKey);
+    }
+
+    private IQueryable<ExternalApiRateLimitReservation> ActiveBucketReservations(
+        AppDbContext dbContext,
+        string operation,
+        DateTimeOffset now)
+    {
+        return CurrentBucketReservations(dbContext, operation)
+            .Where(x => x.ExpiresAtUtc > now);
+    }
+
+    private async Task DeleteExpiredReservationsAsync(
+        AppDbContext dbContext,
+        string operation,
+        DateTimeOffset now,
+        CancellationToken cancellationToken)
+    {
+        var expired = await CurrentBucketReservations(dbContext, operation)
+            .Where(x => x.ExpiresAtUtc <= now)
+            .ToListAsync(cancellationToken);
+        dbContext.ExternalApiRateLimitReservations.RemoveRange(expired);
+    }
+
+    private async Task AcquireAppLockAsync(
+        AppDbContext dbContext,
+        string operation,
+        CancellationToken cancellationToken)
+    {
+        var resource = BuildAppLockResource(operation, _options.BucketKey);
+        var lockTimeoutMs = (int)Math.Min(
+            int.MaxValue,
+            Math.Max(0, _options.SqlLockTimeout.TotalMilliseconds));
+
+        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+            DECLARE @lockResult int;
+            EXEC @lockResult = sp_getapplock
+                @Resource = {resource},
+                @LockMode = 'Exclusive',
+                @LockOwner = 'Transaction',
+                @LockTimeout = {lockTimeoutMs};
+            IF @lockResult < 0
+            BEGIN
+                THROW 51000, 'Failed to acquire Adobe PDF Services rate limit lock.', 1;
+            END
+            """, cancellationToken);
+    }
+
+    private static string BuildAppLockResource(string operation, string bucketKey)
+    {
+        var resource = $"{Provider}:{operation}:{bucketKey}";
+        if (resource.Length <= 255)
+        {
+            return resource;
+        }
+
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(resource)));
+        return $"{Provider}:{operation}:{hash}";
+    }
+
+    private static async Task<DateTimeOffset> GetDatabaseUtcNowAsync(
+        AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        await using var command = dbContext.Database.GetDbConnection().CreateCommand();
+        command.Transaction = dbContext.Database.CurrentTransaction?.GetDbTransaction();
+        command.CommandText = "SELECT SYSUTCDATETIME()";
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+
+        return result switch
+        {
+            DateTime dateTime => new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)),
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
+            _ => DateTimeOffset.UtcNow,
+        };
+    }
+
+    public sealed record AdobePdfServicesRateLimitOptions(
+        bool Enabled,
+        int RequestsPerWindow,
+        TimeSpan Window,
+        TimeSpan ThrottleCooldown,
+        string BucketKey,
+        TimeSpan WaitLogThreshold,
+        TimeSpan SqlLockTimeout)
+    {
+        public static AdobePdfServicesRateLimitOptions FromConfiguration(IConfiguration configuration)
+        {
+            var enabled =
+                GetBool(configuration, "AdobePdfServices:RateLimit:Enabled", "ADOBE_PDF_SERVICES_RATE_LIMIT_ENABLED")
+                ?? true;
+            var requestsPerWindow = Math.Max(
+                1,
+                GetInt(
+                    configuration,
+                    "AdobePdfServices:RateLimit:RequestsPerMinute",
+                    "ADOBE_PDF_SERVICES_RATE_LIMIT_REQUESTS_PER_MINUTE")
+                ?? 20);
+            var windowSeconds = Math.Max(
+                1,
+                GetDouble(
+                    configuration,
+                    "AdobePdfServices:RateLimit:WindowSeconds",
+                    "ADOBE_PDF_SERVICES_RATE_LIMIT_WINDOW_SECONDS")
+                ?? 60);
+            var cooldownSeconds = Math.Max(
+                0,
+                GetDouble(
+                    configuration,
+                    "AdobePdfServices:RateLimit:ThrottleCooldownSeconds",
+                    "ADOBE_PDF_SERVICES_RATE_LIMIT_THROTTLE_COOLDOWN_SECONDS")
+                ?? 90);
+            var waitLogThresholdSeconds = Math.Max(
+                0,
+                GetDouble(
+                    configuration,
+                    "AdobePdfServices:RateLimit:WaitLogThresholdSeconds",
+                    "ADOBE_PDF_SERVICES_RATE_LIMIT_WAIT_LOG_THRESHOLD_SECONDS")
+                ?? 5);
+            var sqlLockTimeoutSeconds = Math.Max(
+                1,
+                GetDouble(
+                    configuration,
+                    "AdobePdfServices:RateLimit:SqlLockTimeoutSeconds",
+                    "ADOBE_PDF_SERVICES_RATE_LIMIT_SQL_LOCK_TIMEOUT_SECONDS")
+                ?? 15);
+
+            var bucketKey =
+                configuration["AdobePdfServices:RateLimit:BucketKey"]
+                ?? configuration["AdobePdfServices__RateLimit__BucketKey"]
+                ?? configuration["ADOBE_PDF_SERVICES_RATE_LIMIT_BUCKET_KEY"]
+                ?? configuration["PDF_SERVICES_CLIENT_ID"]
+                ?? configuration["AdobePdfServices:ClientId"]
+                ?? configuration["AdobePdfServices__ClientId"]
+                ?? "default";
+
+            return new AdobePdfServicesRateLimitOptions(
+                enabled,
+                requestsPerWindow,
+                TimeSpan.FromSeconds(windowSeconds),
+                TimeSpan.FromSeconds(cooldownSeconds),
+                Truncate(bucketKey.Trim(), 128),
+                TimeSpan.FromSeconds(waitLogThresholdSeconds),
+                TimeSpan.FromSeconds(sqlLockTimeoutSeconds));
+        }
+
+        private static bool? GetBool(IConfiguration configuration, string key, string legacyKey)
+        {
+            return configuration.GetValue<bool?>(key)
+                   ?? configuration.GetValue<bool?>(key.Replace(":", "__", StringComparison.Ordinal))
+                   ?? configuration.GetValue<bool?>(legacyKey);
+        }
+
+        private static int? GetInt(IConfiguration configuration, string key, string legacyKey)
+        {
+            return configuration.GetValue<int?>(key)
+                   ?? configuration.GetValue<int?>(key.Replace(":", "__", StringComparison.Ordinal))
+                   ?? configuration.GetValue<int?>(legacyKey);
+        }
+
+        private static double? GetDouble(IConfiguration configuration, string key, string legacyKey)
+        {
+            return configuration.GetValue<double?>(key)
+                   ?? configuration.GetValue<double?>(key.Replace(":", "__", StringComparison.Ordinal))
+                   ?? configuration.GetValue<double?>(legacyKey);
+        }
+
+        private static string Truncate(string value, int maxLength)
+        {
+            if (value.Length <= maxLength)
+            {
+                return value;
+            }
+
+            return value[..maxLength];
+        }
+    }
+}

--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -71,15 +71,20 @@ public static class IngestServiceCollectionExtensions
 
         if (options.UseAdobePdfServices)
         {
+            services.AddSingleton<IAdobePdfServicesRateLimiter, SqlAdobePdfServicesRateLimiter>();
             services.AddSingleton<IAdobePdfServices>(sp =>
             {
                 var configuration = sp.GetRequiredService<IConfiguration>();
                 EnsureAdobeCredentialsConfigured(configuration);
-                return new AdobePdfServices(configuration, sp.GetRequiredService<ILogger<AdobePdfServices>>());
+                return new AdobePdfServices(
+                    configuration,
+                    sp.GetRequiredService<ILogger<AdobePdfServices>>(),
+                    sp.GetRequiredService<IAdobePdfServicesRateLimiter>());
             });
         }
         else
         {
+            services.AddSingleton<IAdobePdfServicesRateLimiter, NoopAdobePdfServicesRateLimiter>();
             services.AddSingleton<IAdobePdfServices, NoopAdobePdfServices>();
         }
         services.AddSingleton<IAutotagProvider>(sp => sp.GetRequiredService<IAdobePdfServices>());

--- a/server.core/Migrations/20260501214218_AddExternalApiRateLimitTables.Designer.cs
+++ b/server.core/Migrations/20260501214218_AddExternalApiRateLimitTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using server.core.Data;
 
@@ -11,9 +12,11 @@ using server.core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501214218_AddExternalApiRateLimitTables")]
+    partial class AddExternalApiRateLimitTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server.core/Migrations/20260501214218_AddExternalApiRateLimitTables.cs
+++ b/server.core/Migrations/20260501214218_AddExternalApiRateLimitTables.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalApiRateLimitTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExternalApiRateLimitBuckets",
+                columns: table => new
+                {
+                    Provider = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Operation = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    BucketKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    PausedUntilUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    UpdatedAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalApiRateLimitBuckets", x => new { x.Provider, x.Operation, x.BucketKey });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ExternalApiRateLimitReservations",
+                columns: table => new
+                {
+                    ReservationId = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Provider = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Operation = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    BucketKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    RequestId = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Cost = table.Column<int>(type: "int", nullable: false),
+                    ReservedAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    ExpiresAtUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalApiRateLimitReservations", x => x.ReservationId);
+                    table.CheckConstraint("CK_ExternalApiRateLimitReservations_Cost", "[Cost] > 0");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalApiRateLimitBuckets_PausedUntilUtc",
+                table: "ExternalApiRateLimitBuckets",
+                column: "PausedUntilUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalApiRateLimitReservations_Provider_Operation_BucketKey_ExpiresAtUtc",
+                table: "ExternalApiRateLimitReservations",
+                columns: new[] { "Provider", "Operation", "BucketKey", "ExpiresAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalApiRateLimitReservations_RequestId",
+                table: "ExternalApiRateLimitReservations",
+                column: "RequestId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalApiRateLimitBuckets");
+
+            migrationBuilder.DropTable(
+                name: "ExternalApiRateLimitReservations");
+        }
+    }
+}

--- a/tests/server.tests/Ingest/AdobePdfServicesRateLimiterTests.cs
+++ b/tests/server.tests/Ingest/AdobePdfServicesRateLimiterTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using server.core.Data;
+using server.core.Ingest;
+
+namespace server.tests.Ingest;
+
+public class AdobePdfServicesRateLimiterTests
+{
+    [Fact]
+    public void Options_FromConfiguration_UsesConservativeDefaults()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PDF_SERVICES_CLIENT_ID"] = "client-id",
+            })
+            .Build();
+
+        var options = SqlAdobePdfServicesRateLimiter.AdobePdfServicesRateLimitOptions
+            .FromConfiguration(configuration);
+
+        options.Enabled.Should().BeTrue();
+        options.RequestsPerWindow.Should().Be(20);
+        options.Window.Should().Be(TimeSpan.FromSeconds(60));
+        options.ThrottleCooldown.Should().Be(TimeSpan.FromSeconds(90));
+        options.BucketKey.Should().Be("client-id");
+    }
+
+    [Fact]
+    public void Options_FromConfiguration_AllowsOperationalOverrides()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AdobePdfServices:RateLimit:Enabled"] = "false",
+                ["AdobePdfServices:RateLimit:RequestsPerMinute"] = "12",
+                ["AdobePdfServices:RateLimit:WindowSeconds"] = "30",
+                ["AdobePdfServices:RateLimit:ThrottleCooldownSeconds"] = "45",
+                ["AdobePdfServices:RateLimit:BucketKey"] = "bucket",
+                ["AdobePdfServices:RateLimit:WaitLogThresholdSeconds"] = "7",
+                ["AdobePdfServices:RateLimit:SqlLockTimeoutSeconds"] = "9",
+            })
+            .Build();
+
+        var options = SqlAdobePdfServicesRateLimiter.AdobePdfServicesRateLimitOptions
+            .FromConfiguration(configuration);
+
+        options.Enabled.Should().BeFalse();
+        options.RequestsPerWindow.Should().Be(12);
+        options.Window.Should().Be(TimeSpan.FromSeconds(30));
+        options.ThrottleCooldown.Should().Be(TimeSpan.FromSeconds(45));
+        options.BucketKey.Should().Be("bucket");
+        options.WaitLogThreshold.Should().Be(TimeSpan.FromSeconds(7));
+        options.SqlLockTimeout.Should().Be(TimeSpan.FromSeconds(9));
+    }
+
+    [Fact]
+    public void AddFileIngest_WithNoops_RegistersNoopRateLimiter()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+
+        services.AddFileIngest(options => options.UseNoops());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IAdobePdfServicesRateLimiter>()
+            .Should().BeOfType<NoopAdobePdfServicesRateLimiter>();
+    }
+
+    [Fact]
+    public void AddFileIngest_WithAdobeServices_RegistersSqlRateLimiter()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseInMemoryDatabase($"rate-limiter-{Guid.NewGuid():N}"));
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["PDF_SERVICES_CLIENT_ID"] = "client-id",
+                    ["PDF_SERVICES_CLIENT_SECRET"] = "client-secret",
+                })
+                .Build());
+
+        services.AddFileIngest(options =>
+        {
+            options.UseAdobePdfServices = true;
+            options.AutotagProvider = FileIngestOptions.AutotagProviders.Adobe;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IAdobePdfServicesRateLimiter>()
+            .Should().BeOfType<SqlAdobePdfServicesRateLimiter>();
+    }
+
+    [Fact]
+    public async Task WaitAsync_WhenDisabled_ReturnsWithoutTouchingSql()
+    {
+        using var provider = CreateInMemoryProvider();
+        var dbContextFactory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        using var loggerFactory = LoggerFactory.Create(_ => { });
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AdobePdfServices:RateLimit:Enabled"] = "false",
+            })
+            .Build();
+        var limiter = new SqlAdobePdfServicesRateLimiter(
+            dbContextFactory,
+            configuration,
+            loggerFactory.CreateLogger<SqlAdobePdfServicesRateLimiter>());
+
+        await limiter.WaitAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            cost: 1,
+            CancellationToken.None);
+
+        await limiter.RecordThrottleAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            new InvalidOperationException("rate limited"),
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task WaitAsync_WhenCostExceedsCapacity_ThrowsBeforeTouchingSql()
+    {
+        using var provider = CreateInMemoryProvider();
+        var dbContextFactory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        using var loggerFactory = LoggerFactory.Create(_ => { });
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AdobePdfServices:RateLimit:RequestsPerMinute"] = "2",
+            })
+            .Build();
+        var limiter = new SqlAdobePdfServicesRateLimiter(
+            dbContextFactory,
+            configuration,
+            loggerFactory.CreateLogger<SqlAdobePdfServicesRateLimiter>());
+
+        var act = async () => await limiter.WaitAsync(
+            AdobePdfServicesRateLimitOperations.AccessibilityChecker,
+            cost: 3,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*exceeds configured capacity*");
+    }
+
+    private static ServiceProvider CreateInMemoryProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseInMemoryDatabase($"rate-limiter-{Guid.NewGuid():N}"));
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/server.tests/Ingest/AdobePdfServicesRateLimiterTests.cs
+++ b/tests/server.tests/Ingest/AdobePdfServicesRateLimiterTests.cs
@@ -74,7 +74,7 @@ public class AdobePdfServicesRateLimiterTests
     }
 
     [Fact]
-    public void AddFileIngest_WithAdobeServices_RegistersSqlRateLimiter()
+    public void AddFileIngest_WithAdobeServicesAndRateLimitDisabled_RegistersSqlRateLimiter()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -86,6 +86,7 @@ public class AdobePdfServicesRateLimiterTests
                 {
                     ["PDF_SERVICES_CLIENT_ID"] = "client-id",
                     ["PDF_SERVICES_CLIENT_SECRET"] = "client-secret",
+                    ["AdobePdfServices:RateLimit:Enabled"] = "false",
                 })
                 .Build());
 
@@ -99,6 +100,28 @@ public class AdobePdfServicesRateLimiterTests
 
         provider.GetRequiredService<IAdobePdfServicesRateLimiter>()
             .Should().BeOfType<SqlAdobePdfServicesRateLimiter>();
+    }
+
+    [Fact]
+    public void Constructor_WhenEnabledWithNonSqlServerProvider_ThrowsClearProviderError()
+    {
+        using var provider = CreateInMemoryProvider();
+        var dbContextFactory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        using var loggerFactory = LoggerFactory.Create(_ => { });
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PDF_SERVICES_CLIENT_ID"] = "client-id",
+            })
+            .Build();
+
+        var act = () => new SqlAdobePdfServicesRateLimiter(
+            dbContextFactory,
+            configuration,
+            loggerFactory.CreateLogger<SqlAdobePdfServicesRateLimiter>());
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*SqlAdobePdfServicesRateLimiter*SQL Server*sp_getapplock*SYSUTCDATETIME()*InMemory*");
     }
 
     [Fact]
@@ -132,7 +155,7 @@ public class AdobePdfServicesRateLimiterTests
     [Fact]
     public async Task WaitAsync_WhenCostExceedsCapacity_ThrowsBeforeTouchingSql()
     {
-        using var provider = CreateInMemoryProvider();
+        using var provider = CreateSqlServerProvider();
         var dbContextFactory = provider.GetRequiredService<IDbContextFactory<AppDbContext>>();
         using var loggerFactory = LoggerFactory.Create(_ => { });
         var configuration = new ConfigurationBuilder()
@@ -160,6 +183,15 @@ public class AdobePdfServicesRateLimiterTests
         var services = new ServiceCollection();
         services.AddDbContextFactory<AppDbContext>(options =>
             options.UseInMemoryDatabase($"rate-limiter-{Guid.NewGuid():N}"));
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider CreateSqlServerProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseSqlServer(
+                "Server=(localdb)\\mssqllocaldb;Database=readable-rate-limiter-tests;Trusted_Connection=True;"));
         return services.BuildServiceProvider();
     }
 }

--- a/tests/server.tests/Workers/IngestWorkerHostJsonTests.cs
+++ b/tests/server.tests/Workers/IngestWorkerHostJsonTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace server.tests.Workers;
+
+public class IngestWorkerHostJsonTests
+{
+    [Fact]
+    public void HostJson_ConfiguresServiceBusBackpressure()
+    {
+        var repoRoot = FindRepoRoot();
+        var hostJsonPath = Path.Combine(repoRoot, "workers", "function.ingest", "host.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(hostJsonPath));
+        var serviceBus = document.RootElement
+            .GetProperty("extensions")
+            .GetProperty("serviceBus");
+
+        serviceBus.GetProperty("prefetchCount").GetInt32().Should().Be(0);
+        serviceBus.GetProperty("maxConcurrentCalls").GetInt32().Should().Be(4);
+        serviceBus.GetProperty("autoCompleteMessages").GetBoolean().Should().BeFalse();
+        serviceBus.GetProperty("maxAutoLockRenewalDuration").GetString().Should().Be("00:35:00");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "app.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not find repository root.");
+    }
+}

--- a/tests/server.tests/Workers/ProcessQueueMessageTests.cs
+++ b/tests/server.tests/Workers/ProcessQueueMessageTests.cs
@@ -1,0 +1,182 @@
+using Azure.Messaging.ServiceBus;
+using function.ingest;
+using FluentAssertions;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging.Abstractions;
+using server.core.Ingest;
+
+namespace server.tests.Workers;
+
+public class ProcessQueueMessageTests
+{
+    [Fact]
+    public async Task Run_WhenCloudEventIsMalformed_DeadLettersAndDoesNotProcess()
+    {
+        var processor = new CapturingFileIngestProcessor();
+        var actions = new RecordingServiceBusMessageActions();
+        var handler = CreateHandler(processor);
+        var message = CreateMessage("{not-json", deliveryCount: 2);
+
+        await handler.Run(message, actions, CancellationToken.None);
+
+        processor.ProcessCalls.Should().Be(0);
+        actions.DeadLetterCalls.Should().Be(1);
+        actions.DeadLetterReason.Should().Be("InvalidCloudEvent");
+        actions.CompleteCalls.Should().Be(0);
+        actions.AbandonCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Run_WhenProcessingFails_AbandonsAndRethrows()
+    {
+        var processor = new CapturingFileIngestProcessor
+        {
+            ProcessException = new InvalidOperationException("processing failed"),
+        };
+        var actions = new RecordingServiceBusMessageActions();
+        var handler = CreateHandler(processor);
+        var message = CreateMessage(CreateBlobCreatedCloudEvent());
+
+        var act = async () => await handler.Run(message, actions, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("processing failed");
+        processor.ProcessCalls.Should().Be(1);
+        actions.AbandonCalls.Should().Be(1);
+        actions.CompleteCalls.Should().Be(0);
+        actions.DeadLetterCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Run_WhenCompleteFailsAfterProcessing_DoesNotAbandon()
+    {
+        var processor = new CapturingFileIngestProcessor();
+        var actions = new RecordingServiceBusMessageActions
+        {
+            CompleteException = new InvalidOperationException("complete failed"),
+        };
+        var handler = CreateHandler(processor);
+        var message = CreateMessage(CreateBlobCreatedCloudEvent());
+
+        var act = async () => await handler.Run(message, actions, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("complete failed");
+        processor.ProcessCalls.Should().Be(1);
+        actions.CompleteCalls.Should().Be(1);
+        actions.AbandonCalls.Should().Be(0);
+        actions.DeadLetterCalls.Should().Be(0);
+    }
+
+    private static ProcessQueueMessage CreateHandler(CapturingFileIngestProcessor processor)
+    {
+        return new ProcessQueueMessage(
+            NullLogger<ProcessQueueMessage>.Instance,
+            processor,
+            new IngestQueueOptions(
+                FilesQueueName: "files",
+                OpenDataLoaderAutotagQueueName: "autotag",
+                FinalizeQueueName: "finalize",
+                FailedQueueName: "failed"));
+    }
+
+    private static ServiceBusReceivedMessage CreateMessage(string body, int deliveryCount = 1)
+    {
+        return ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString(body),
+            messageId: "message-1",
+            contentType: "application/json",
+            deliveryCount: deliveryCount);
+    }
+
+    private static string CreateBlobCreatedCloudEvent()
+    {
+        return """
+            {
+              "specversion": "1.0",
+              "type": "Microsoft.Storage.BlobCreated",
+              "source": "/subscriptions/test/resourceGroups/test/providers/Microsoft.Storage/storageAccounts/account",
+              "id": "event-1",
+              "time": "2026-05-03T00:00:00Z",
+              "data": {
+                "url": "https://account.blob.core.windows.net/incoming/file-1.pdf"
+              }
+            }
+            """;
+    }
+
+    private sealed class CapturingFileIngestProcessor : IFileIngestProcessor
+    {
+        public int ProcessCalls { get; private set; }
+
+        public Exception? ProcessException { get; init; }
+
+        public Task ProcessAsync(BlobIngestRequest request, CancellationToken cancellationToken)
+        {
+            ProcessCalls++;
+            if (ProcessException is not null)
+            {
+                throw ProcessException;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task FinalizeAsync(FinalizePdfMessage message, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task FailAsync(AutotagFailedMessage message, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class RecordingServiceBusMessageActions : ServiceBusMessageActions
+    {
+        public int CompleteCalls { get; private set; }
+
+        public int AbandonCalls { get; private set; }
+
+        public int DeadLetterCalls { get; private set; }
+
+        public string? DeadLetterReason { get; private set; }
+
+        public Exception? CompleteException { get; init; }
+
+        public override Task CompleteMessageAsync(
+            ServiceBusReceivedMessage message,
+            CancellationToken cancellationToken = default)
+        {
+            CompleteCalls++;
+            if (CompleteException is not null)
+            {
+                throw CompleteException;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public override Task AbandonMessageAsync(
+            ServiceBusReceivedMessage message,
+            IDictionary<string, object>? propertiesToModify = null,
+            CancellationToken cancellationToken = default)
+        {
+            AbandonCalls++;
+            return Task.CompletedTask;
+        }
+
+        public override Task DeadLetterMessageAsync(
+            ServiceBusReceivedMessage message,
+            Dictionary<string, object>? propertiesToModify = null,
+            string? deadLetterReason = null,
+            string? deadLetterErrorDescription = null,
+            CancellationToken cancellationToken = default)
+        {
+            DeadLetterCalls++;
+            DeadLetterReason = deadLetterReason;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/server.tests/server.tests.csproj
+++ b/tests/server.tests/server.tests.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\server.core\server.core.csproj" />
     <ProjectReference Include="..\..\server\server.csproj" />
+    <ProjectReference Include="..\..\workers\function.ingest\function_ingest.csproj" />
     <ProjectReference Include="..\..\workers\opendataloader.api\opendataloader.api.csproj" />
   </ItemGroup>
 

--- a/workers/function.ingest/FailedQueueMessage.cs
+++ b/workers/function.ingest/FailedQueueMessage.cs
@@ -49,29 +49,48 @@ public class FailedQueueMessage
             ["messaging.message.id"] = message.MessageId
         });
 
+        var body = message.Body.ToString();
+        var failedMessage = IngestQueueMessageJson.Deserialize<AutotagFailedMessage>(body);
+
+        activity?.SetTag("file.id", failedMessage.FileId);
+        activity?.SetTag("autotag.provider", failedMessage.Provider);
+        activity?.SetTag("error.type", failedMessage.ErrorCode);
+
+        using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["file.id"] = failedMessage.FileId,
+            ["autotag.provider"] = failedMessage.Provider,
+            ["error.type"] = failedMessage.ErrorCode
+        });
+
         try
         {
-            var body = message.Body.ToString();
-            var failedMessage = IngestQueueMessageJson.Deserialize<AutotagFailedMessage>(body);
-
-            activity?.SetTag("file.id", failedMessage.FileId);
-            activity?.SetTag("autotag.provider", failedMessage.Provider);
-            activity?.SetTag("error.type", failedMessage.ErrorCode);
-
-            using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
-            {
-                ["file.id"] = failedMessage.FileId,
-                ["autotag.provider"] = failedMessage.Provider,
-                ["error.type"] = failedMessage.ErrorCode
-            });
-
             await _fileIngestProcessor.FailAsync(failedMessage, cancellationToken);
-
-            await messageActions.CompleteMessageAsync(message, cancellationToken);
         }
         catch (Exception ex)
         {
             await AbandonMessageAsync(message, messageActions, ex);
+            throw;
+        }
+
+        await CompleteMessageAsync(message, messageActions, cancellationToken);
+    }
+
+    private async Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
+                message.MessageId);
             throw;
         }
     }

--- a/workers/function.ingest/FailedQueueMessage.cs
+++ b/workers/function.ingest/FailedQueueMessage.cs
@@ -49,22 +49,49 @@ public class FailedQueueMessage
             ["messaging.message.id"] = message.MessageId
         });
 
-        var body = message.Body.ToString();
-        var failedMessage = IngestQueueMessageJson.Deserialize<AutotagFailedMessage>(body);
-
-        activity?.SetTag("file.id", failedMessage.FileId);
-        activity?.SetTag("autotag.provider", failedMessage.Provider);
-        activity?.SetTag("error.type", failedMessage.ErrorCode);
-
-        using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+        try
         {
-            ["file.id"] = failedMessage.FileId,
-            ["autotag.provider"] = failedMessage.Provider,
-            ["error.type"] = failedMessage.ErrorCode
-        });
+            var body = message.Body.ToString();
+            var failedMessage = IngestQueueMessageJson.Deserialize<AutotagFailedMessage>(body);
 
-        await _fileIngestProcessor.FailAsync(failedMessage, cancellationToken);
+            activity?.SetTag("file.id", failedMessage.FileId);
+            activity?.SetTag("autotag.provider", failedMessage.Provider);
+            activity?.SetTag("error.type", failedMessage.ErrorCode);
 
-        await messageActions.CompleteMessageAsync(message, cancellationToken);
+            using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["file.id"] = failedMessage.FileId,
+                ["autotag.provider"] = failedMessage.Provider,
+                ["error.type"] = failedMessage.ErrorCode
+            });
+
+            await _fileIngestProcessor.FailAsync(failedMessage, cancellationToken);
+
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await AbandonMessageAsync(message, messageActions, ex);
+            throw;
+        }
+    }
+
+    private async Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        Exception exception)
+    {
+        try
+        {
+            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
+        }
+        catch (Exception abandonException)
+        {
+            _logger.LogWarning(
+                abandonException,
+                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
+                message.MessageId,
+                exception.GetType().Name);
+        }
     }
 }

--- a/workers/function.ingest/FailedQueueMessage.cs
+++ b/workers/function.ingest/FailedQueueMessage.cs
@@ -69,48 +69,10 @@ public class FailedQueueMessage
         }
         catch (Exception ex)
         {
-            await AbandonMessageAsync(message, messageActions, ex);
+            await ServiceBusMessageSettlement.AbandonMessageAsync(message, messageActions, _logger, ex);
             throw;
         }
 
-        await CompleteMessageAsync(message, messageActions, cancellationToken);
-    }
-
-    private async Task CompleteMessageAsync(
-        ServiceBusReceivedMessage message,
-        ServiceBusMessageActions messageActions,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await messageActions.CompleteMessageAsync(message, cancellationToken);
-        }
-        catch (Exception exception)
-        {
-            _logger.LogError(
-                exception,
-                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
-                message.MessageId);
-            throw;
-        }
-    }
-
-    private async Task AbandonMessageAsync(
-        ServiceBusReceivedMessage message,
-        ServiceBusMessageActions messageActions,
-        Exception exception)
-    {
-        try
-        {
-            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
-        }
-        catch (Exception abandonException)
-        {
-            _logger.LogWarning(
-                abandonException,
-                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
-                message.MessageId,
-                exception.GetType().Name);
-        }
+        await ServiceBusMessageSettlement.CompleteMessageAsync(message, messageActions, _logger, cancellationToken);
     }
 }

--- a/workers/function.ingest/FinalizeQueueMessage.cs
+++ b/workers/function.ingest/FinalizeQueueMessage.cs
@@ -69,48 +69,10 @@ public class FinalizeQueueMessage
         }
         catch (Exception ex)
         {
-            await AbandonMessageAsync(message, messageActions, ex);
+            await ServiceBusMessageSettlement.AbandonMessageAsync(message, messageActions, _logger, ex);
             throw;
         }
 
-        await CompleteMessageAsync(message, messageActions, cancellationToken);
-    }
-
-    private async Task CompleteMessageAsync(
-        ServiceBusReceivedMessage message,
-        ServiceBusMessageActions messageActions,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await messageActions.CompleteMessageAsync(message, cancellationToken);
-        }
-        catch (Exception exception)
-        {
-            _logger.LogError(
-                exception,
-                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
-                message.MessageId);
-            throw;
-        }
-    }
-
-    private async Task AbandonMessageAsync(
-        ServiceBusReceivedMessage message,
-        ServiceBusMessageActions messageActions,
-        Exception exception)
-    {
-        try
-        {
-            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
-        }
-        catch (Exception abandonException)
-        {
-            _logger.LogWarning(
-                abandonException,
-                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
-                message.MessageId,
-                exception.GetType().Name);
-        }
+        await ServiceBusMessageSettlement.CompleteMessageAsync(message, messageActions, _logger, cancellationToken);
     }
 }

--- a/workers/function.ingest/FinalizeQueueMessage.cs
+++ b/workers/function.ingest/FinalizeQueueMessage.cs
@@ -49,22 +49,49 @@ public class FinalizeQueueMessage
             ["messaging.message.id"] = message.MessageId
         });
 
-        var body = message.Body.ToString();
-        var finalizeMessage = IngestQueueMessageJson.Deserialize<FinalizePdfMessage>(body);
-
-        activity?.SetTag("file.id", finalizeMessage.FileId);
-        activity?.SetTag("url.full", finalizeMessage.PdfToFinalizeBlobUri.ToString());
-        activity?.SetTag("autotag.provider", finalizeMessage.Autotag.Provider);
-
-        using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+        try
         {
-            ["file.id"] = finalizeMessage.FileId,
-            ["url.full"] = finalizeMessage.PdfToFinalizeBlobUri.ToString(),
-            ["autotag.provider"] = finalizeMessage.Autotag.Provider
-        });
+            var body = message.Body.ToString();
+            var finalizeMessage = IngestQueueMessageJson.Deserialize<FinalizePdfMessage>(body);
 
-        await _fileIngestProcessor.FinalizeAsync(finalizeMessage, cancellationToken);
+            activity?.SetTag("file.id", finalizeMessage.FileId);
+            activity?.SetTag("url.full", finalizeMessage.PdfToFinalizeBlobUri.ToString());
+            activity?.SetTag("autotag.provider", finalizeMessage.Autotag.Provider);
 
-        await messageActions.CompleteMessageAsync(message, cancellationToken);
+            using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["file.id"] = finalizeMessage.FileId,
+                ["url.full"] = finalizeMessage.PdfToFinalizeBlobUri.ToString(),
+                ["autotag.provider"] = finalizeMessage.Autotag.Provider
+            });
+
+            await _fileIngestProcessor.FinalizeAsync(finalizeMessage, cancellationToken);
+
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await AbandonMessageAsync(message, messageActions, ex);
+            throw;
+        }
+    }
+
+    private async Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        Exception exception)
+    {
+        try
+        {
+            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
+        }
+        catch (Exception abandonException)
+        {
+            _logger.LogWarning(
+                abandonException,
+                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
+                message.MessageId,
+                exception.GetType().Name);
+        }
     }
 }

--- a/workers/function.ingest/FinalizeQueueMessage.cs
+++ b/workers/function.ingest/FinalizeQueueMessage.cs
@@ -49,29 +49,48 @@ public class FinalizeQueueMessage
             ["messaging.message.id"] = message.MessageId
         });
 
+        var body = message.Body.ToString();
+        var finalizeMessage = IngestQueueMessageJson.Deserialize<FinalizePdfMessage>(body);
+
+        activity?.SetTag("file.id", finalizeMessage.FileId);
+        activity?.SetTag("url.full", finalizeMessage.PdfToFinalizeBlobUri.ToString());
+        activity?.SetTag("autotag.provider", finalizeMessage.Autotag.Provider);
+
+        using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["file.id"] = finalizeMessage.FileId,
+            ["url.full"] = finalizeMessage.PdfToFinalizeBlobUri.ToString(),
+            ["autotag.provider"] = finalizeMessage.Autotag.Provider
+        });
+
         try
         {
-            var body = message.Body.ToString();
-            var finalizeMessage = IngestQueueMessageJson.Deserialize<FinalizePdfMessage>(body);
-
-            activity?.SetTag("file.id", finalizeMessage.FileId);
-            activity?.SetTag("url.full", finalizeMessage.PdfToFinalizeBlobUri.ToString());
-            activity?.SetTag("autotag.provider", finalizeMessage.Autotag.Provider);
-
-            using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
-            {
-                ["file.id"] = finalizeMessage.FileId,
-                ["url.full"] = finalizeMessage.PdfToFinalizeBlobUri.ToString(),
-                ["autotag.provider"] = finalizeMessage.Autotag.Provider
-            });
-
             await _fileIngestProcessor.FinalizeAsync(finalizeMessage, cancellationToken);
-
-            await messageActions.CompleteMessageAsync(message, cancellationToken);
         }
         catch (Exception ex)
         {
             await AbandonMessageAsync(message, messageActions, ex);
+            throw;
+        }
+
+        await CompleteMessageAsync(message, messageActions, cancellationToken);
+    }
+
+    private async Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
+                message.MessageId);
             throw;
         }
     }

--- a/workers/function.ingest/ProcessQueueMessage.cs
+++ b/workers/function.ingest/ProcessQueueMessage.cs
@@ -48,50 +48,69 @@ public class ProcessQueueMessage
             ["messaging.message.id"] = message.MessageId
         });
 
+        var body = message.Body.ToString();
+        _logger.LogInformation("Message ID: {id}", message.MessageId);
+        _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
+
+        if (!StorageBlobCreatedEventParser.TryParse(body, out var request, out var error))
+        {
+            var parseError = error ?? "Invalid CloudEvent.";
+            _logger.LogError(
+                "Failed to parse CloudEvent message {messageId}. contentType={contentType}; deliveryCount={deliveryCount}; error={error}",
+                message.MessageId,
+                message.ContentType,
+                message.DeliveryCount,
+                parseError);
+
+            await messageActions.DeadLetterMessageAsync(
+                message,
+                deadLetterReason: "InvalidCloudEvent",
+                deadLetterErrorDescription: parseError,
+                cancellationToken: cancellationToken);
+            return;
+        }
+
+        activity?.SetTag("url.full", request.BlobUri.ToString());
+        activity?.SetTag("blob.container", request.ContainerName);
+        activity?.SetTag("blob.name", request.BlobName);
+        activity?.SetTag("file.id", request.FileId);
+
+        using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["file.id"] = request.FileId,
+            ["blob.container"] = request.ContainerName,
+            ["blob.name"] = request.BlobName,
+            ["url.full"] = request.BlobUri.ToString()
+        });
+
         try
         {
-            var body = message.Body.ToString();
-            _logger.LogInformation("Message ID: {id}", message.MessageId);
-            _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
-
-            if (!StorageBlobCreatedEventParser.TryParse(body, out var request, out var error))
-            {
-                var parseError = error ?? "Invalid CloudEvent.";
-                _logger.LogError(
-                    "Failed to parse CloudEvent message {messageId}. contentType={contentType}; deliveryCount={deliveryCount}; error={error}",
-                    message.MessageId,
-                    message.ContentType,
-                    message.DeliveryCount,
-                    parseError);
-
-                await messageActions.DeadLetterMessageAsync(
-                    message,
-                    deadLetterReason: "InvalidCloudEvent",
-                    deadLetterErrorDescription: parseError,
-                    cancellationToken: cancellationToken);
-                return;
-            }
-
-            activity?.SetTag("url.full", request.BlobUri.ToString());
-            activity?.SetTag("blob.container", request.ContainerName);
-            activity?.SetTag("blob.name", request.BlobName);
-            activity?.SetTag("file.id", request.FileId);
-
-            using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
-            {
-                ["file.id"] = request.FileId,
-                ["blob.container"] = request.ContainerName,
-                ["blob.name"] = request.BlobName,
-                ["url.full"] = request.BlobUri.ToString()
-            });
-
             await _fileIngestProcessor.ProcessAsync(request, cancellationToken);
-
-            await messageActions.CompleteMessageAsync(message, cancellationToken);
         }
         catch (Exception ex)
         {
             await AbandonMessageAsync(message, messageActions, ex);
+            throw;
+        }
+
+        await CompleteMessageAsync(message, messageActions, cancellationToken);
+    }
+
+    private async Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
+                message.MessageId);
             throw;
         }
     }

--- a/workers/function.ingest/ProcessQueueMessage.cs
+++ b/workers/function.ingest/ProcessQueueMessage.cs
@@ -89,48 +89,10 @@ public class ProcessQueueMessage
         }
         catch (Exception ex)
         {
-            await AbandonMessageAsync(message, messageActions, ex);
+            await ServiceBusMessageSettlement.AbandonMessageAsync(message, messageActions, _logger, ex);
             throw;
         }
 
-        await CompleteMessageAsync(message, messageActions, cancellationToken);
-    }
-
-    private async Task CompleteMessageAsync(
-        ServiceBusReceivedMessage message,
-        ServiceBusMessageActions messageActions,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await messageActions.CompleteMessageAsync(message, cancellationToken);
-        }
-        catch (Exception exception)
-        {
-            _logger.LogError(
-                exception,
-                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
-                message.MessageId);
-            throw;
-        }
-    }
-
-    private async Task AbandonMessageAsync(
-        ServiceBusReceivedMessage message,
-        ServiceBusMessageActions messageActions,
-        Exception exception)
-    {
-        try
-        {
-            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
-        }
-        catch (Exception abandonException)
-        {
-            _logger.LogWarning(
-                abandonException,
-                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
-                message.MessageId,
-                exception.GetType().Name);
-        }
+        await ServiceBusMessageSettlement.CompleteMessageAsync(message, messageActions, _logger, cancellationToken);
     }
 }

--- a/workers/function.ingest/ProcessQueueMessage.cs
+++ b/workers/function.ingest/ProcessQueueMessage.cs
@@ -48,32 +48,58 @@ public class ProcessQueueMessage
             ["messaging.message.id"] = message.MessageId
         });
 
-        var body = message.Body.ToString();
-        _logger.LogInformation("Message ID: {id}", message.MessageId);
-        _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
-
-        if (!StorageBlobCreatedEventParser.TryParse(body, out var request, out var error))
+        try
         {
-            _logger.LogError("Failed to parse CloudEvent message: {error}. Body: {body}", error, body);
-            throw new InvalidOperationException(error);
+            var body = message.Body.ToString();
+            _logger.LogInformation("Message ID: {id}", message.MessageId);
+            _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
+
+            if (!StorageBlobCreatedEventParser.TryParse(body, out var request, out var error))
+            {
+                _logger.LogError("Failed to parse CloudEvent message: {error}. Body: {body}", error, body);
+                throw new InvalidOperationException(error);
+            }
+
+            activity?.SetTag("url.full", request.BlobUri.ToString());
+            activity?.SetTag("blob.container", request.ContainerName);
+            activity?.SetTag("blob.name", request.BlobName);
+            activity?.SetTag("file.id", request.FileId);
+
+            using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["file.id"] = request.FileId,
+                ["blob.container"] = request.ContainerName,
+                ["blob.name"] = request.BlobName,
+                ["url.full"] = request.BlobUri.ToString()
+            });
+
+            await _fileIngestProcessor.ProcessAsync(request, cancellationToken);
+
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
         }
-
-        activity?.SetTag("url.full", request.BlobUri.ToString());
-        activity?.SetTag("blob.container", request.ContainerName);
-        activity?.SetTag("blob.name", request.BlobName);
-        activity?.SetTag("file.id", request.FileId);
-
-        using var fileScope = _logger.BeginScope(new Dictionary<string, object?>
+        catch (Exception ex)
         {
-            ["file.id"] = request.FileId,
-            ["blob.container"] = request.ContainerName,
-            ["blob.name"] = request.BlobName,
-            ["url.full"] = request.BlobUri.ToString()
-        });
+            await AbandonMessageAsync(message, messageActions, ex);
+            throw;
+        }
+    }
 
-        await _fileIngestProcessor.ProcessAsync(request, cancellationToken);
-
-        // Complete the message
-        await messageActions.CompleteMessageAsync(message, cancellationToken);
+    private async Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        Exception exception)
+    {
+        try
+        {
+            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
+        }
+        catch (Exception abandonException)
+        {
+            _logger.LogWarning(
+                abandonException,
+                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
+                message.MessageId,
+                exception.GetType().Name);
+        }
     }
 }

--- a/workers/function.ingest/ProcessQueueMessage.cs
+++ b/workers/function.ingest/ProcessQueueMessage.cs
@@ -56,8 +56,20 @@ public class ProcessQueueMessage
 
             if (!StorageBlobCreatedEventParser.TryParse(body, out var request, out var error))
             {
-                _logger.LogError("Failed to parse CloudEvent message: {error}. Body: {body}", error, body);
-                throw new InvalidOperationException(error);
+                var parseError = error ?? "Invalid CloudEvent.";
+                _logger.LogError(
+                    "Failed to parse CloudEvent message {messageId}. contentType={contentType}; deliveryCount={deliveryCount}; error={error}",
+                    message.MessageId,
+                    message.ContentType,
+                    message.DeliveryCount,
+                    parseError);
+
+                await messageActions.DeadLetterMessageAsync(
+                    message,
+                    deadLetterReason: "InvalidCloudEvent",
+                    deadLetterErrorDescription: parseError,
+                    cancellationToken: cancellationToken);
+                return;
             }
 
             activity?.SetTag("url.full", request.BlobUri.ToString());

--- a/workers/function.ingest/ServiceBusMessageSettlement.cs
+++ b/workers/function.ingest/ServiceBusMessageSettlement.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace function.ingest;
+
+internal static class ServiceBusMessageSettlement
+{
+    public static async Task CompleteMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await messageActions.CompleteMessageAsync(message, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Failed to complete Service Bus message {messageId}; not abandoning after successful processing.",
+                message.MessageId);
+            throw;
+        }
+    }
+
+    public static async Task AbandonMessageAsync(
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions,
+        ILogger logger,
+        Exception exception)
+    {
+        try
+        {
+            await messageActions.AbandonMessageAsync(message, cancellationToken: CancellationToken.None);
+        }
+        catch (Exception abandonException)
+        {
+            logger.LogWarning(
+                abandonException,
+                "Failed to abandon Service Bus message {messageId} after processing error {errorType}",
+                message.MessageId,
+                exception.GetType().Name);
+        }
+    }
+}

--- a/workers/function.ingest/host.json
+++ b/workers/function.ingest/host.json
@@ -19,6 +19,9 @@
     },
     "extensions": {
         "serviceBus": {
+            "prefetchCount": 0,
+            "autoCompleteMessages": false,
+            "maxConcurrentCalls": 4,
             "maxAutoLockRenewalDuration": "00:35:00"
         }
     }


### PR DESCRIPTION
- Adds SQL-backed rate limiting to coordinate external service calls across workers
- Introduces database tables to track usage buckets and request reservations
- Implements automatic cooldown periods when throttling is detected
- Refines worker message handling to explicitly manage completion and abandonment
- Configures service bus concurrency and prefetch settings for better backpressure
- Adds configuration options for rate limit windows and throughput capacities


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent external API rate-limit tracking and a pluggable Adobe PDF Services rate limiter with integration into ingestion flows.

* **Bug Fixes**
  * Robust Service Bus message settlement: dead-letter malformed events, abandon on failures, and ensure correct complete/abandon behavior; improved retry/polling for accessibility checks.

* **Chores**
  * Tuned Service Bus host configuration and DI registration for rate limiter selection.

* **Tests**
  * Added comprehensive tests for rate limiting, configuration parsing, and queue processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->