### PR TITLE
Add XFA accessibility report warning

### DIFF
--- a/client/src/queries/files.ts
+++ b/client/src/queries/files.ts
@@ -24,20 +24,27 @@ export type AccessibilityReportDetails = AccessibilityReportListItem & {
   reportJson: AccessibilityReportJson;
 };
 
+export type AccessibilityReportWarning = {
+  code: string;
+  message: string;
+  stage: string;
+};
+
 export type UserFile = {
   accessibilityReports?: AccessibilityReportListItem[];
   contentType: string;
   createdAt: string;
   fileId: string;
+  latestFailureReason?: string | null;
   originalFileName: string;
   sizeBytes: number;
   status: string;
   statusUpdatedAt: string;
-  latestFailureReason?: string | null;
 };
 
 export type UserFileDetails = Omit<UserFile, 'accessibilityReports'> & {
   accessibilityReports: AccessibilityReportDetails[];
+  accessibilityReportWarnings?: AccessibilityReportWarning[];
 };
 
 export const myFilesQueryOptions = () => ({
@@ -146,4 +153,3 @@ export function useDownloadFilesAsZipMutation() {
     mutationFn: (fileIds: string[]) => downloadFilesAsZip(fileIds),
   });
 }
-

--- a/client/src/routes/(authenticated)/reports/$fileId/index.tsx
+++ b/client/src/routes/(authenticated)/reports/$fileId/index.tsx
@@ -30,6 +30,15 @@ type FlattenedRule = {
   status: string;
 };
 
+const XFA_HELP_URL =
+  'https://experienceleague.adobe.com/en/docs/experience-manager-learn/forms/document-services/pdf-forms-and-documents';
+
+function hasXfaUnsupportedWarning(
+  warnings: { code: string }[] | undefined
+) {
+  return warnings?.some((w) => w.code === 'XfaUnsupported') ?? false;
+}
+
 function getSummaryCounts(reportJson: AccessibilityReportJson | undefined) {
   const summary = reportJson?.Summary;
   if (!summary || typeof summary !== 'object') {
@@ -263,6 +272,10 @@ function RouteComponent() {
 
   const file = fileQuery.data;
   const isCompleted = file.status === 'Completed';
+  const hasReports = (file.accessibilityReports?.length ?? 0) > 0;
+  const hasXfaReportWarning = hasXfaUnsupportedWarning(
+    file.accessibilityReportWarnings
+  );
 
   const afterFailed = afterRows.filter((r) => isFailedStatus(r.status));
 
@@ -326,8 +339,40 @@ function RouteComponent() {
           </div>
         ) : null}
 
-        {!file.accessibilityReports ||
-        file.accessibilityReports.length === 0 ? (
+        {!hasReports && hasXfaReportWarning ? (
+          <div className="alert alert-warning">
+            <span>
+              Readable processed this PDF, but an accessibility report could
+              not be generated because the Adobe accessibility checker cannot
+              analyze XFA form PDFs.{' '}
+              <a
+                className="link font-semibold"
+                href={XFA_HELP_URL}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                Learn more about XFA PDF forms.
+              </a>
+            </span>
+          </div>
+        ) : !hasReports && isCompleted ? (
+          <div className="alert alert-warning">
+            <span>
+              Readable processed this PDF, but an accessibility report could
+              not be generated. This can happen when the Adobe accessibility
+              checker does not support the PDF format, including some XFA form
+              PDFs.{' '}
+              <a
+                className="link font-semibold"
+                href={XFA_HELP_URL}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                Learn more about XFA PDF forms.
+              </a>
+            </span>
+          </div>
+        ) : !hasReports ? (
           <div className="alert alert-info">
             <span>No accessibility reports found for this file yet.</span>
           </div>

--- a/client/src/test/routes/(authenticated)/index.test.tsx
+++ b/client/src/test/routes/(authenticated)/index.test.tsx
@@ -11,6 +11,9 @@ describe('authenticated index route', () => {
     let userRequestCount = 0;
 
     server.use(
+      http.get('/api/status/banner', () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
       http.get('/api/user/me', () => {
         userRequestCount += 1;
         return HttpResponse.json({

--- a/client/src/test/routes/reports.test.tsx
+++ b/client/src/test/routes/reports.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/mswUtils.ts';
+import { renderRoute } from '@/test/routerUtils.tsx';
+
+describe('report route', () => {
+  it('explains when an XFA PDF cannot be checked', async () => {
+    const fileId = '6b45b501-2b20-4f55-8491-73cf55747a61';
+
+    server.use(
+      http.get('/api/status/banner', () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.get('/api/user/me', () => {
+        return HttpResponse.json({
+          email: 'user@example.com',
+          id: 'user-1',
+          name: 'Test User',
+          roles: [],
+        });
+      }),
+      http.get(`/api/file/${fileId}`, () => {
+        return HttpResponse.json({
+          accessibilityReports: [],
+          accessibilityReportWarnings: [
+            {
+              code: 'XfaUnsupported',
+              message:
+                'The Adobe accessibility checker cannot analyze XFA form PDFs.',
+              stage: 'After',
+            },
+          ],
+          contentType: 'application/pdf',
+          createdAt: '2026-05-04T18:05:00Z',
+          fileId,
+          latestFailureReason: null,
+          originalFileName: 'xfa.pdf',
+          sizeBytes: 123,
+          status: 'Completed',
+          statusUpdatedAt: '2026-05-04T18:09:29Z',
+        });
+      })
+    );
+
+    const { cleanup } = renderRoute({ initialPath: `/reports/${fileId}` });
+
+    try {
+      expect(
+        await screen.findByText(
+          /Readable processed this PDF, but an accessibility report could not be generated because the Adobe accessibility checker cannot analyze XFA form PDFs\./
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', { name: 'Learn more about XFA PDF forms.' })
+      ).toHaveAttribute(
+        'href',
+        'https://experienceleague.adobe.com/en/docs/experience-manager-learn/forms/document-services/pdf-forms-and-documents'
+      );
+      expect(
+        screen.queryByText('No accessibility reports found for this file yet.')
+      ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/server.core/Ingest/FileIngestProcessor.cs
+++ b/server.core/Ingest/FileIngestProcessor.cs
@@ -987,6 +987,9 @@ public sealed class FileIngestProcessor : IFileIngestProcessor
 
     private string BuildMetadataJson(PdfProcessResult? pdfResult, int pageCount)
     {
+        var accessibilityReportWarnings =
+            pdfResult?.AccessibilityReportWarnings ?? Array.Empty<PdfAccessibilityReportWarning>();
+
         var metadata = new
         {
             configuration = new
@@ -1002,6 +1005,10 @@ public sealed class FileIngestProcessor : IFileIngestProcessor
             processing = new
             {
                 pageCount,
+            },
+            accessibilityReports = new
+            {
+                warnings = accessibilityReportWarnings,
             },
             autotag = pdfResult?.Autotag
         };

--- a/server.core/Ingest/PdfProcessor.cs
+++ b/server.core/Ingest/PdfProcessor.cs
@@ -35,14 +35,27 @@ public sealed record PdfProcessResult(
     string? AfterAccessibilityReportJson = null,
     string? AfterAccessibilityReportPath = null,
     int PageCount = 0,
-    PdfAutotagMetadata? Autotag = null);
+    PdfAutotagMetadata? Autotag = null,
+    IReadOnlyList<PdfAccessibilityReportWarning>? AccessibilityReportWarnings = null);
 
 public sealed record PdfIntakeResult(
     bool RequiresAutotag,
     int PageCount,
     string? BeforeAccessibilityReportJson,
     string? BeforeAccessibilityReportPath,
-    PdfAutotagMetadata Autotag);
+    PdfAutotagMetadata Autotag,
+    IReadOnlyList<PdfAccessibilityReportWarning>? AccessibilityReportWarnings = null);
+
+public sealed record PdfAccessibilityReportWarning(
+    string Stage,
+    string Code,
+    string Message);
+
+public static class PdfAccessibilityReportWarningCodes
+{
+    public const string XfaUnsupported = "XfaUnsupported";
+    public const string CheckerFailed = "CheckerFailed";
+}
 
 public sealed record PdfFinalizeContext(
     int PageCount,
@@ -161,6 +174,8 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
         var sourcePageCount = TryReadPageCount(sourcePath);
         EnforceMaxUploadPages(sourcePageCount);
 
+        var accessibilityReportWarnings = new List<PdfAccessibilityReportWarning>();
+
         // Best-effort: generate a "before" accessibility report on the original uploaded PDF.
         AdobeAccessibilityCheckOutput? beforeAccessibilityReport = null;
         try
@@ -190,6 +205,7 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to generate BEFORE accessibility report for {fileId}", fileId);
+            accessibilityReportWarnings.Add(BuildAccessibilityReportWarning("Before", ex));
         }
 
         var pageCount = 0;
@@ -420,6 +436,7 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to generate accessibility report for {fileId}", fileId);
+            accessibilityReportWarnings.Add(BuildAccessibilityReportWarning("After", ex));
         }
 
         _logger.LogInformation(
@@ -435,7 +452,8 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
             accessibilityReport?.ReportJson,
             accessibilityReport?.ReportPath,
             PageCount: pageCount,
-            Autotag: autotagMetadata);
+            Autotag: autotagMetadata,
+            AccessibilityReportWarnings: accessibilityReportWarnings);
     }
 
     public async Task<PdfIntakeResult> PrepareForQueuedAutotagAsync(
@@ -458,6 +476,7 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
         var sourcePageCount = TryReadPageCount(sourcePath);
         EnforceMaxUploadPages(sourcePageCount);
 
+        var accessibilityReportWarnings = new List<PdfAccessibilityReportWarning>();
         AdobeAccessibilityCheckOutput? beforeAccessibilityReport = null;
         try
         {
@@ -486,6 +505,7 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to generate BEFORE accessibility report for {fileId}", fileId);
+            accessibilityReportWarnings.Add(BuildAccessibilityReportWarning("Before", ex));
         }
 
         var sourceInfo = ReadSourcePdfInfo(
@@ -516,7 +536,8 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
                     Required: false,
                     SkippedReason: "already-tagged",
                     ChunkCount: 0,
-                    LocalReportPaths: []));
+                    LocalReportPaths: []),
+                AccessibilityReportWarnings: accessibilityReportWarnings);
         }
 
         if (sourceInfo.TaggingState == PdfTaggingState.TaggedBroken && retagTriggers.Count > 0)
@@ -537,7 +558,8 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
                 Required: true,
                 SkippedReason: null,
                 ChunkCount: 1,
-                LocalReportPaths: []));
+                LocalReportPaths: []),
+            AccessibilityReportWarnings: accessibilityReportWarnings);
     }
 
     public async Task<PdfProcessResult> FinalizeTaggedPdfAsync(
@@ -581,6 +603,7 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
             finalPdfPath = taggedPdfPath;
         }
 
+        var accessibilityReportWarnings = new List<PdfAccessibilityReportWarning>();
         AdobeAccessibilityCheckOutput? accessibilityReport = null;
         try
         {
@@ -609,6 +632,7 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to generate accessibility report for {fileId}", fileId);
+            accessibilityReportWarnings.Add(BuildAccessibilityReportWarning("After", ex));
         }
 
         _logger.LogInformation(
@@ -624,7 +648,37 @@ public sealed class PdfProcessor : IPdfPipelineProcessor
             AfterAccessibilityReportJson: accessibilityReport?.ReportJson,
             AfterAccessibilityReportPath: accessibilityReport?.ReportPath,
             PageCount: context.PageCount,
-            Autotag: context.Autotag);
+            Autotag: context.Autotag,
+            AccessibilityReportWarnings: accessibilityReportWarnings);
+    }
+
+    private static PdfAccessibilityReportWarning BuildAccessibilityReportWarning(string stage, Exception exception)
+    {
+        if (IsXfaUnsupportedException(exception))
+        {
+            return new PdfAccessibilityReportWarning(
+                stage,
+                PdfAccessibilityReportWarningCodes.XfaUnsupported,
+                "The Adobe accessibility checker cannot analyze XFA form PDFs.");
+        }
+
+        return new PdfAccessibilityReportWarning(
+            stage,
+            PdfAccessibilityReportWarningCodes.CheckerFailed,
+            "The Adobe accessibility checker could not generate an accessibility report.");
+    }
+
+    private static bool IsXfaUnsupportedException(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current.Message.Contains("XFA", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private string GetAutotagProviderName()

--- a/server/Controllers/FileController.cs
+++ b/server/Controllers/FileController.cs
@@ -132,6 +132,7 @@ public class FileController : ApiControllerBase
                 .Select(a => a.ErrorMessage)
                 .FirstOrDefault(),
             AccessibilityReports = reports,
+            AccessibilityReportWarnings = GetAccessibilityReportWarnings(file.ProcessingAttempts),
         });
     }
 
@@ -201,6 +202,71 @@ public class FileController : ApiControllerBase
         };
     }
 
+    private static List<AccessibilityReportWarningDto> GetAccessibilityReportWarnings(
+        IEnumerable<FileProcessingAttempt> attempts)
+    {
+        var metadataJson = attempts
+            .Where(a => !string.IsNullOrWhiteSpace(a.MetadataJson))
+            .OrderByDescending(a => a.AttemptNumber)
+            .Select(a => a.MetadataJson)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(metadataJson))
+        {
+            return [];
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(metadataJson);
+            if (!doc.RootElement.TryGetProperty("accessibilityReports", out var accessibilityReports) ||
+                !accessibilityReports.TryGetProperty("warnings", out var warnings) ||
+                warnings.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var result = new List<AccessibilityReportWarningDto>();
+            foreach (var warning in warnings.EnumerateArray())
+            {
+                if (warning.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
+
+                var stage = GetStringProperty(warning, "stage");
+                var code = GetStringProperty(warning, "code");
+                var message = GetStringProperty(warning, "message");
+                if (string.IsNullOrWhiteSpace(stage) ||
+                    string.IsNullOrWhiteSpace(code) ||
+                    string.IsNullOrWhiteSpace(message))
+                {
+                    continue;
+                }
+
+                result.Add(new AccessibilityReportWarningDto
+                {
+                    Stage = stage,
+                    Code = code,
+                    Message = message,
+                });
+            }
+
+            return result;
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
     public sealed class FileListItemDto
     {
         public Guid FileId { get; init; }
@@ -225,6 +291,7 @@ public class FileController : ApiControllerBase
         public DateTimeOffset StatusUpdatedAt { get; init; }
         public string? LatestFailureReason { get; init; }
         public List<AccessibilityReportDetailsDto> AccessibilityReports { get; set; } = [];
+        public List<AccessibilityReportWarningDto> AccessibilityReportWarnings { get; set; } = [];
     }
 
     public sealed class AccessibilityReportListItemDto
@@ -247,5 +314,11 @@ public class FileController : ApiControllerBase
         public int? IssueCount { get; init; }
         public JsonElement ReportJson { get; init; }
     }
-}
 
+    public sealed class AccessibilityReportWarningDto
+    {
+        public string Stage { get; init; } = string.Empty;
+        public string Code { get; init; } = string.Empty;
+        public string Message { get; init; } = string.Empty;
+    }
+}

--- a/tests/server.tests/Controllers/FileControllerTests.cs
+++ b/tests/server.tests/Controllers/FileControllerTests.cs
@@ -167,6 +167,73 @@ public class FileControllerTests
     }
 
     [Fact]
+    public async Task GetById_when_attempt_metadata_has_report_warning_returns_warning()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var user = new User
+        {
+            UserId = 1,
+            EntraObjectId = Guid.NewGuid(),
+            Email = "test@example.com",
+            DisplayName = "Test User",
+        };
+        ctx.Users.Add(user);
+
+        var fileId = Guid.NewGuid();
+        ctx.Files.Add(new FileRecord
+        {
+            FileId = fileId,
+            OwnerUserId = user.UserId,
+            OwnerUser = user,
+            OriginalFileName = "xfa.pdf",
+            ContentType = "application/pdf",
+            SizeBytes = 123,
+            Status = FileRecord.Statuses.Completed,
+            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            StatusUpdatedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        });
+
+        ctx.FileProcessingAttempts.Add(new FileProcessingAttempt
+        {
+            FileId = fileId,
+            AttemptNumber = 1,
+            Trigger = FileProcessingAttempt.Triggers.Upload,
+            Outcome = FileProcessingAttempt.Outcomes.Succeeded,
+            StartedAt = DateTimeOffset.UtcNow.AddMinutes(-4),
+            FinishedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            MetadataJson =
+                "{\"accessibilityReports\":{\"warnings\":[{\"stage\":\"After\",\"code\":\"XfaUnsupported\",\"message\":\"The Adobe accessibility checker cannot analyze XFA form PDFs.\"}]}}",
+        });
+
+        await ctx.SaveChangesAsync();
+
+        var controller = new FileController(ctx);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = BuildUser(user.UserId),
+            },
+        };
+
+        var result = await controller.GetById(fileId, CancellationToken.None);
+        result.Result.Should().BeOfType<OkObjectResult>();
+
+        var ok = (OkObjectResult)result.Result!;
+        var dto = (FileController.FileDetailsDto)ok.Value!;
+
+        dto.AccessibilityReports.Should().BeEmpty();
+        dto.AccessibilityReportWarnings.Should().ContainSingle().Which.Should().BeEquivalentTo(
+            new FileController.AccessibilityReportWarningDto
+            {
+                Stage = "After",
+                Code = "XfaUnsupported",
+                Message = "The Adobe accessibility checker cannot analyze XFA form PDFs.",
+            });
+    }
+
+    [Fact]
     public async Task List_when_file_failed_returns_latest_failure_reason()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
@@ -246,4 +313,3 @@ public class FileControllerTests
         return new ClaimsPrincipal(identity);
     }
 }
-

--- a/tests/server.tests/Ingest/FileIngestProcessorTests.cs
+++ b/tests/server.tests/Ingest/FileIngestProcessorTests.cs
@@ -137,6 +137,70 @@ public class FileIngestProcessorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WhenAccessibilityCheckerWarningExists_PersistsWarningInMetadata()
+    {
+        var fileId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"ingest_{Guid.NewGuid():N}")
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        await SeedFileAsync(options, fileId, "xfa.pdf");
+
+        var tempDirectory = CreateTempDirectory();
+        try
+        {
+            var dbContextFactory = new InMemoryDbContextFactory(options);
+            var pdf = new WarningPdfProcessor(CreateTempPdf(tempDirectory));
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+
+            var sut = new FileIngestProcessor(
+                dbContextFactory,
+                new FakeBlobStreamOpener(),
+                pdf,
+                new FakeBlobStorage(),
+                new ConfigurationBuilder().Build(),
+                Options.Create(new PdfProcessorOptions()),
+                loggerFactory.CreateLogger<FileIngestProcessor>());
+
+            var request = new BlobIngestRequest(
+                new Uri("https://example.blob.core.windows.net/incoming/xfa.pdf"),
+                "incoming",
+                "xfa.pdf",
+                fileId.ToString());
+
+            await sut.ProcessAsync(request, CancellationToken.None);
+
+            await using var verify = new AppDbContext(options);
+            var reports = await verify.AccessibilityReports
+                .Where(x => x.FileId == fileId)
+                .ToListAsync();
+            reports.Should().BeEmpty();
+
+            var attempt = await verify.FileProcessingAttempts.SingleAsync(x => x.FileId == fileId);
+            attempt.Outcome.Should().Be(FileProcessingAttempt.Outcomes.Succeeded);
+            attempt.MetadataJson.Should().NotBeNullOrWhiteSpace();
+
+            using var metadata = JsonDocument.Parse(attempt.MetadataJson!);
+            var warnings = metadata.RootElement
+                .GetProperty("accessibilityReports")
+                .GetProperty("warnings")
+                .EnumerateArray()
+                .ToList();
+            warnings.Should().ContainSingle();
+
+            var warning = warnings.Single();
+            warning.GetProperty("stage").GetString().Should().Be("After");
+            warning.GetProperty("code").GetString().Should().Be(PdfAccessibilityReportWarningCodes.XfaUnsupported);
+            warning.GetProperty("message").GetString().Should().Be("The Adobe accessibility checker cannot analyze XFA form PDFs.");
+        }
+        finally
+        {
+            DeleteTempDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
     public async Task ProcessAsync_WithOpenDataLoaderProvider_EnqueuesAutotagAndLeavesAttemptOpen()
     {
         var fileId = Guid.NewGuid();
@@ -1059,6 +1123,30 @@ public class FileIngestProcessorTests
         public Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
         {
             throw new InvalidOperationException("boom");
+        }
+    }
+
+    private sealed class WarningPdfProcessor : IPdfProcessor
+    {
+        private readonly string _outputPath;
+
+        public WarningPdfProcessor(string outputPath)
+        {
+            _outputPath = outputPath;
+        }
+
+        public Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new PdfProcessResult(
+                _outputPath,
+                PageCount: 2,
+                AccessibilityReportWarnings:
+                [
+                    new PdfAccessibilityReportWarning(
+                        "After",
+                        PdfAccessibilityReportWarningCodes.XfaUnsupported,
+                        "The Adobe accessibility checker cannot analyze XFA form PDFs.")
+                ]));
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility report warnings to provide detailed feedback when reports cannot be generated.
  * Introduced XFA PDF support with guidance and documentation links for files that cannot be analyzed.
  * Enhanced status messaging to clarify when files require manual accessibility review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->