### PR TITLE
feat: Make PDF upload page limit configurable

### DIFF
--- a/client/src/components/pdf/PdfUploadDropzone.tsx
+++ b/client/src/components/pdf/PdfUploadDropzone.tsx
@@ -5,6 +5,7 @@ import {
 } from 'react';
 import { ArrowUpTrayIcon } from '@heroicons/react/24/solid';
 import { Link } from '@tanstack/react-router';
+import { maxUploadPages } from '@/config/pdfUploadLimits.ts';
 
 export type PdfUploadDropzoneProps = {
   isUploading: boolean;
@@ -81,9 +82,14 @@ export function PdfUploadDropzone({
       <div className="mt-3 text-xs text-base-content/70">
         PDF only · Multiple files supported
       </div>
-      <div className="alert alert-primary mt-4 max-w-md text-left text-sm">
-        <span>Temporary upload limit: PDFs must be 25 pages or fewer.</span>
-      </div>
+      {maxUploadPages > 0 ? (
+        <div className="alert alert-primary mt-4 max-w-md text-left text-sm">
+          <span>
+            Temporary upload limit: PDFs must be {maxUploadPages} pages or
+            fewer.
+          </span>
+        </div>
+      ) : null}
       <p className="mt-2 max-w-sm text-xs text-base-content/60">
         Best results come from text-based PDFs. Scanned, handwritten, or
         image-only content may need manual transcription first.{' '}

--- a/client/src/config/pdfUploadLimits.ts
+++ b/client/src/config/pdfUploadLimits.ts
@@ -1,8 +1,13 @@
 const defaultMaxUploadPages = 100;
 
-const configuredMaxUploadPages = Number(import.meta.env.VITE_MAX_UPLOAD_PAGES);
+const configuredMaxUploadPages = import.meta.env.VITE_MAX_UPLOAD_PAGES;
+const parsedMaxUploadPages =
+  typeof configuredMaxUploadPages === 'string' &&
+  /^\d+$/.test(configuredMaxUploadPages)
+    ? parseInt(configuredMaxUploadPages, 10)
+    : Number.NaN;
 
 export const maxUploadPages =
-  Number.isFinite(configuredMaxUploadPages) && configuredMaxUploadPages >= 0
-    ? configuredMaxUploadPages
+  Number.isFinite(parsedMaxUploadPages) && parsedMaxUploadPages >= 0
+    ? parsedMaxUploadPages
     : defaultMaxUploadPages;

--- a/client/src/config/pdfUploadLimits.ts
+++ b/client/src/config/pdfUploadLimits.ts
@@ -1,0 +1,8 @@
+const defaultMaxUploadPages = 100;
+
+const configuredMaxUploadPages = Number(import.meta.env.VITE_MAX_UPLOAD_PAGES);
+
+export const maxUploadPages =
+  Number.isFinite(configuredMaxUploadPages) && configuredMaxUploadPages >= 0
+    ? configuredMaxUploadPages
+    : defaultMaxUploadPages;

--- a/infrastructure/azure/main.bicep
+++ b/infrastructure/azure/main.bicep
@@ -30,6 +30,10 @@ param sqlDatabaseName string = appName
 @description('Service Bus queue base name. Leave empty for `files`.')
 param serviceBusQueueBaseName string = ''
 
+@minValue(0)
+@description('Maximum allowed page count for uploaded PDFs. Set to 0 to disable the temporary upload page limit.')
+param maxUploadPages int = 100
+
 @description('Additional resource tags to apply.')
 param tags object = {}
 
@@ -275,6 +279,7 @@ module compute 'modules/compute.bicep' = {
     ingestOpenDataLoaderAutotagQueueName: openDataLoaderAutotagQueueName
     ingestFinalizeQueueName: finalizeQueueName
     ingestFailedQueueName: failedQueueName
+    maxUploadPages: maxUploadPages
   }
 }
 

--- a/infrastructure/azure/modules/compute.bicep
+++ b/infrastructure/azure/modules/compute.bicep
@@ -83,6 +83,10 @@ param ingestFinalizeQueueName string = 'pdf-finalize'
 @description('Queue consumed by the ingest failure function.')
 param ingestFailedQueueName string = 'pdf-failed'
 
+@minValue(0)
+@description('Maximum allowed page count for uploaded PDFs. Set to 0 to disable the temporary upload page limit.')
+param maxUploadPages int = 100
+
 @allowed([
   512
   2048
@@ -257,6 +261,10 @@ resource functionApp 'Microsoft.Web/sites@2025-03-01' = {
         {
           name: 'INGEST_FAILED_QUEUE_NAME'
           value: ingestFailedQueueName
+        }
+        {
+          name: 'INGEST_MAX_UPLOAD_PAGES'
+          value: string(maxUploadPages)
         }
       ], appInsightsConnectionString != '' ? [
         {

--- a/server.core/Ingest/FileIngestOptions.cs
+++ b/server.core/Ingest/FileIngestOptions.cs
@@ -2,6 +2,8 @@ namespace server.core.Ingest;
 
 public sealed class FileIngestOptions
 {
+    public const int DefaultMaxUploadPages = 100;
+
     public bool UseAdobePdfServices { get; set; }
     public bool UsePdfRemediationProcessor { get; set; }
     public bool UsePdfBookmarks { get; set; }
@@ -9,7 +11,7 @@ public sealed class FileIngestOptions
     public string AutotagProvider { get; set; } = AutotagProviders.Adobe;
 
     public int PdfMaxPagesPerChunk { get; set; } = 200;
-    public int MaxUploadPages { get; set; }
+    public int MaxUploadPages { get; set; } = DefaultMaxUploadPages;
     public string? PdfWorkDirRoot { get; set; }
 
     public void UseNoops()

--- a/server.core/Ingest/PdfProcessorOptions.cs
+++ b/server.core/Ingest/PdfProcessorOptions.cs
@@ -31,7 +31,7 @@ public sealed class PdfProcessorOptions
     /// Maximum allowed page count for uploaded PDFs.
     /// Set to 0 or less to disable the limit.
     /// </summary>
-    public int MaxUploadPages { get; set; }
+    public int MaxUploadPages { get; set; } = FileIngestOptions.DefaultMaxUploadPages;
 
     /// <summary>
     /// Root directory for PDF ingest work. If null/empty, defaults to /tmp (when available) or <see cref="Path.GetTempPath"/>.

--- a/tests/server.tests/Ingest/FileIngestProcessorTests.cs
+++ b/tests/server.tests/Ingest/FileIngestProcessorTests.cs
@@ -70,7 +70,7 @@ public class FileIngestProcessorTests
                 UsePdfBookmarks = true,
                 AutotagTaggedPdfs = false,
                 MaxPagesPerChunk = 200,
-                MaxUploadPages = 25,
+                MaxUploadPages = FileIngestOptions.DefaultMaxUploadPages,
             }),
             loggerFactory.CreateLogger<FileIngestProcessor>());
 
@@ -251,7 +251,7 @@ public class FileIngestProcessorTests
                 UseAdobePdfServices = true,
                 UsePdfRemediationProcessor = true,
                 MaxPagesPerChunk = 200,
-                MaxUploadPages = 25,
+                MaxUploadPages = FileIngestOptions.DefaultMaxUploadPages,
             }),
             loggerFactory.CreateLogger<FileIngestProcessor>());
 
@@ -1152,8 +1152,8 @@ public class FileIngestProcessorTests
 
     private sealed class PageLimitThrowingPdfProcessor : IPdfProcessor
     {
-        public int ActualPageCount { get; } = 31;
-        public int MaxAllowedPages { get; } = 25;
+        public int ActualPageCount { get; } = FileIngestOptions.DefaultMaxUploadPages + 1;
+        public int MaxAllowedPages { get; } = FileIngestOptions.DefaultMaxUploadPages;
 
         public Task<PdfProcessResult> ProcessAsync(string fileId, Stream pdfStream, CancellationToken cancellationToken)
         {

--- a/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
+++ b/tests/server.tests/Integration/Ingest/PdfProcessorIntegrationTests.cs
@@ -263,7 +263,9 @@ public sealed class PdfProcessorIntegrationTests
         try
         {
             var inputPdfPath = Path.Combine(runRoot, "input.pdf");
-            CreateTestPdf(inputPdfPath, pageCount: 26);
+            var maxUploadPages = FileIngestOptions.DefaultMaxUploadPages;
+            var actualPageCount = maxUploadPages + 1;
+            CreateTestPdf(inputPdfPath, pageCount: actualPageCount);
 
             await using var inputStream = File.OpenRead(inputPdfPath);
 
@@ -275,7 +277,7 @@ public sealed class PdfProcessorIntegrationTests
                 UseAdobePdfServices = true,
                 UsePdfRemediationProcessor = true,
                 MaxPagesPerChunk = 200,
-                MaxUploadPages = 25,
+                MaxUploadPages = maxUploadPages,
                 WorkDirRoot = runRoot
             });
 
@@ -284,8 +286,8 @@ public sealed class PdfProcessorIntegrationTests
             var act = () => sut.ProcessAsync(fileId, inputStream, CancellationToken.None);
 
             var ex = await act.Should().ThrowAsync<PdfPageLimitExceededException>();
-            ex.Which.ActualPageCount.Should().Be(26);
-            ex.Which.MaxAllowedPages.Should().Be(25);
+            ex.Which.ActualPageCount.Should().Be(actualPageCount);
+            ex.Which.MaxAllowedPages.Should().Be(maxUploadPages);
             adobe.AutotagCalls.Should().Be(0);
             adobe.AccessibilityCheckCalls.Should().Be(0);
             remediation.Calls.Should().Be(0);
@@ -616,6 +618,5 @@ public sealed class PdfProcessorIntegrationTests
         return pdf.GetNumberOfPages();
     }
 }
-
 
 

--- a/workers/function.ingest/Program.cs
+++ b/workers/function.ingest/Program.cs
@@ -79,7 +79,7 @@ builder.Services.AddFileIngest(o =>
     o.MaxUploadPages =
         builder.Configuration.GetValue<int?>("Ingest:MaxUploadPages")
         ?? builder.Configuration.GetValue<int?>("INGEST_MAX_UPLOAD_PAGES")
-        ?? 25;
+        ?? FileIngestOptions.DefaultMaxUploadPages;
 });
 
 builder.Services.AddApplicationInsightsTelemetryWorkerService();


### PR DESCRIPTION
Introduces system-wide configurability for PDF upload page limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF upload page limit is now configurable via deployment settings and can be disabled by setting the limit to 0.

* **Improvements**
  * Default maximum PDF upload pages increased from 25 to 100.
  * Upload limit message in the UI now displays the actual configured page limit instead of a fixed value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->