### PR TITLE
Fix Form XObject figure alt remediation

### DIFF
--- a/server.core/Properties/AssemblyInfo.cs
+++ b/server.core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("server.tests")]

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -342,6 +342,19 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     fileId);
             }
 
+            PdfXObjectStructureAssociationRemediationResult xObjectStructureRemediation;
+            using (LogStage.Begin(_logger, fileId, "remediate_xobject_structure_associations", null, kind: "Remediation stage"))
+            {
+                xObjectStructureRemediation = PdfXObjectStructureAssociationRemediator.Remediate(pdf, cancellationToken);
+            }
+            _logger.LogInformation(
+                "XObject structure association remediation in {fileId}: inspected={inspected} protected={protected} disconnected={disconnected} inlineAltApplied={inlineAltApplied}.",
+                fileId,
+                xObjectStructureRemediation.Inspected,
+                xObjectStructureRemediation.Protected,
+                xObjectStructureRemediation.Disconnected,
+                xObjectStructureRemediation.InlineAltApplied);
+
             Dictionary<int, int> pageObjNumToPageNumber;
             PdfStructTreeIndex figureIndex;
             using (LogStage.Begin(_logger, fileId, "build_struct_tree_indices", null, kind: "Remediation stage"))

--- a/server.core/Remediate/PdfXObjectStructureAssociationRemediator.cs
+++ b/server.core/Remediate/PdfXObjectStructureAssociationRemediator.cs
@@ -1,0 +1,578 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using iText.Kernel.Pdf;
+
+namespace server.core.Remediate;
+
+internal sealed record PdfXObjectStructureAssociationRemediationResult(
+    int Inspected,
+    int Protected,
+    int Disconnected,
+    int InlineAltApplied = 0);
+
+internal static class PdfXObjectStructureAssociationRemediator
+{
+    // This pass handles XObject structure associations that Acrobat evaluates separately from normal tag-tree
+    // Figure alt text. It preserves meaningful structure claims, disconnects unclaimed XObject residue, and
+    // mirrors tag-tree Figure /Alt into Form XObject inline /Figure marked-content properties when Acrobat
+    // would otherwise report "Other elements alternate text" for the inline marked content.
+    private static readonly PdfName RoleAnnot = new("Annot");
+    private static readonly PdfName RoleFormula = new("Formula");
+    private static readonly PdfName StructParentsKey = new("StructParents");
+    private static readonly Regex FigureMarkedContentDictionaryRegex = new(
+        @"/Figure\s*<<(?<dict>(?:(?:<[^>]*>)|(?:\([^()]*\))|[^<>])*?/MCID\s+(?<mcid>\d+)(?:(?:<[^>]*>)|(?:\([^()]*\))|[^<>])*?)>>\s*BDC",
+        RegexOptions.Compiled);
+
+    public static PdfXObjectStructureAssociationRemediationResult Remediate(
+        PdfDocument pdf,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!pdf.IsTagged())
+        {
+            return new PdfXObjectStructureAssociationRemediationResult(0, 0, 0);
+        }
+
+        var parentTree = TryGetParentTree(pdf);
+        var visitedXObjects = new HashSet<(int objNum, int genNum)>();
+
+        var inspected = 0;
+        var protectedCount = 0;
+        var disconnected = 0;
+        var inlineAltApplied = 0;
+
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var resources = GetPageResources(pdf.GetPage(pageNumber));
+            RemediateResources(
+                resources,
+                parentTree,
+                visitedXObjects,
+                ref inspected,
+                ref protectedCount,
+                ref disconnected,
+                ref inlineAltApplied,
+                cancellationToken);
+        }
+
+        return new PdfXObjectStructureAssociationRemediationResult(
+            inspected,
+            protectedCount,
+            disconnected,
+            inlineAltApplied);
+    }
+
+    private static PdfDictionary? GetPageResources(PdfPage page)
+    {
+        var pageDict = page.GetPdfObject();
+        var resources = pageDict.GetAsDictionary(PdfName.Resources);
+        if (resources is not null)
+        {
+            return resources;
+        }
+
+        var parent = pageDict.GetAsDictionary(PdfName.Parent);
+        while (parent is not null)
+        {
+            resources = parent.GetAsDictionary(PdfName.Resources);
+            if (resources is not null)
+            {
+                return resources;
+            }
+
+            parent = parent.GetAsDictionary(PdfName.Parent);
+        }
+
+        return null;
+    }
+
+    private static void RemediateResources(
+        PdfDictionary? resources,
+        PdfDictionary? parentTree,
+        HashSet<(int objNum, int genNum)> visitedXObjects,
+        ref int inspected,
+        ref int protectedCount,
+        ref int disconnected,
+        ref int inlineAltApplied,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var xObjects = resources?.GetAsDictionary(PdfName.XObject);
+        if (xObjects is null)
+        {
+            return;
+        }
+
+        foreach (var name in xObjects.KeySet())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!TryGetUnvisitedXObjectStream(xObjects.Get(name), visitedXObjects, out var xObject))
+            {
+                continue;
+            }
+
+            var subtype = xObject.GetAsName(PdfName.Subtype);
+            if (!PdfName.Form.Equals(subtype) && !PdfName.Image.Equals(subtype))
+            {
+                continue;
+            }
+
+            inspected++;
+
+            var structParents = xObject.GetAsNumber(StructParentsKey)?.IntValue();
+            if (structParents is not null)
+            {
+                // /StructParents points from an XObject back into the structure parent tree. If that entry is
+                // meaningfully claimed, keep the association and normalize the claim; otherwise remove only the
+                // low-level hook so decorative/autotag residue stops participating in accessibility checks.
+                var claim = AnalyzeParentTreeClaim(parentTree, structParents.Value);
+                NormalizeClaimMarkedContentReferences(claim.StructElements, xObject);
+                inlineAltApplied += ApplyClaimInlineFigureAltText(claim.StructElements, xObject);
+                if (claim.IsProtected)
+                {
+                    protectedCount++;
+                }
+                else
+                {
+                    xObject.Remove(StructParentsKey);
+                    disconnected++;
+                }
+            }
+
+            if (PdfName.Form.Equals(subtype))
+            {
+                RemediateResources(
+                    xObject.GetAsDictionary(PdfName.Resources),
+                    parentTree,
+                    visitedXObjects,
+                    ref inspected,
+                    ref protectedCount,
+                    ref disconnected,
+                    ref inlineAltApplied,
+                    cancellationToken);
+            }
+        }
+    }
+
+    private static bool TryGetUnvisitedXObjectStream(
+        PdfObject? xObjectRefOrStream,
+        HashSet<(int objNum, int genNum)> visitedXObjects,
+        out PdfStream xObject)
+    {
+        xObject = null!;
+        if (xObjectRefOrStream is null || xObjectRefOrStream is PdfNull)
+        {
+            return false;
+        }
+
+        var indirectRef = xObjectRefOrStream as PdfIndirectReference ?? xObjectRefOrStream.GetIndirectReference();
+        if (indirectRef is not null)
+        {
+            var key = (indirectRef.GetObjNumber(), indirectRef.GetGenNumber());
+            if (!visitedXObjects.Add(key))
+            {
+                return false;
+            }
+        }
+
+        var dereferenced = Dereference(xObjectRefOrStream);
+        if (dereferenced is not PdfStream stream)
+        {
+            return false;
+        }
+
+        xObject = stream;
+        return true;
+    }
+
+    private static ParentTreeClaimAnalysis AnalyzeParentTreeClaim(PdfDictionary? parentTree, int structParents)
+    {
+        if (parentTree is null)
+        {
+            return ParentTreeClaimAnalysis.Unclaimed;
+        }
+
+        var claim = TryGetNumberTreeValue(parentTree, structParents);
+        if (claim is null || claim is PdfNull)
+        {
+            return ParentTreeClaimAnalysis.Unclaimed;
+        }
+
+        var structElems = new List<PdfDictionary>();
+        CollectParentTreeClaimStructElements(claim, structElems, new HashSet<(int objNum, int genNum)>());
+        if (structElems.Count == 0)
+        {
+            return ParentTreeClaimAnalysis.Unclaimed;
+        }
+
+        return structElems.Any(IsMeaningfulStructureElement)
+            ? ParentTreeClaimAnalysis.ProtectedClaim(structElems)
+            : ParentTreeClaimAnalysis.Unclaimed;
+    }
+
+    // Some Form-backed MCR dictionaries omit /Pg. Acrobat can still display the tag-tree Figure, but its
+    // content-properties lookup may show a blank Structure Tag. Adding /Pg gives the MCR explicit page context.
+    private static void NormalizeClaimMarkedContentReferences(
+        IReadOnlyList<PdfDictionary> structElems,
+        PdfStream xObject)
+    {
+        if (!PdfName.Form.Equals(xObject.GetAsName(PdfName.Subtype)))
+        {
+            return;
+        }
+
+        var xObjectRef = xObject.GetIndirectReference();
+        if (xObjectRef is null)
+        {
+            return;
+        }
+
+        foreach (var structElem in structElems)
+        {
+            var page = structElem.GetAsDictionary(PdfName.Pg);
+            if (page is null)
+            {
+                continue;
+            }
+
+            var kids = structElem.Get(PdfName.K);
+            if (kids is not null)
+            {
+                NormalizeMarkedContentReferenceKids(kids, page, xObjectRef, new HashSet<(int objNum, int genNum)>());
+            }
+        }
+    }
+
+    private static void NormalizeMarkedContentReferenceKids(
+        PdfObject node,
+        PdfDictionary page,
+        PdfIndirectReference xObjectRef,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        node = Dereference(node, visited);
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                NormalizeMarkedContentReferenceKids(item, page, xObjectRef, visited);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        if (dict.GetAsNumber(PdfName.MCID) is not null
+            && TryReferencesObject(dict.Get(PdfName.Stm), xObjectRef))
+        {
+            if (dict.GetAsDictionary(PdfName.Pg) is null)
+            {
+                dict.Put(PdfName.Pg, page);
+            }
+
+            return;
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            NormalizeMarkedContentReferenceKids(kids, page, xObjectRef, visited);
+        }
+    }
+
+    private static bool TryReferencesObject(PdfObject? obj, PdfIndirectReference targetRef)
+    {
+        var objRef = obj as PdfIndirectReference ?? obj?.GetIndirectReference();
+        return objRef is not null
+            && objRef.GetObjNumber() == targetRef.GetObjNumber()
+            && objRef.GetGenNumber() == targetRef.GetGenNumber();
+    }
+
+    private static int ApplyClaimInlineFigureAltText(
+        IReadOnlyList<PdfDictionary> structElems,
+        PdfStream xObject)
+    {
+        if (!PdfName.Form.Equals(xObject.GetAsName(PdfName.Subtype)))
+        {
+            return 0;
+        }
+
+        var altByMcid = BuildInlineFigureAltTextByMcid(structElems);
+        if (altByMcid.Count == 0)
+        {
+            return 0;
+        }
+
+        // Acrobat's "Other elements alternate text" rule checks /Figure marked content inside Form XObjects.
+        // Copy the already-remediated tag-tree Figure /Alt onto the matching inline /Figure property dictionary;
+        // this does not create new semantics or call AI, it only makes the existing association complete.
+        var content = Encoding.Latin1.GetString(xObject.GetBytes());
+        var applied = 0;
+        var updated = FigureMarkedContentDictionaryRegex.Replace(
+            content,
+            match =>
+            {
+                if (!int.TryParse(match.Groups["mcid"].Value, out var mcid)
+                    || !altByMcid.TryGetValue(mcid, out var alt))
+                {
+                    return match.Value;
+                }
+
+                var dict = match.Groups["dict"].Value.TrimEnd();
+                if (ContainsDictionaryKey(dict, "Alt"))
+                {
+                    return match.Value;
+                }
+
+                applied++;
+                return $"/Figure <<{dict} /Alt <{ToPdfTextStringHex(alt)}> >> BDC";
+            });
+
+        if (applied == 0)
+        {
+            return 0;
+        }
+
+        xObject.SetData(Encoding.Latin1.GetBytes(updated));
+        return applied;
+    }
+
+    private static Dictionary<int, string> BuildInlineFigureAltTextByMcid(IReadOnlyList<PdfDictionary> structElems)
+    {
+        var altByMcid = new Dictionary<int, string>();
+        foreach (var structElem in structElems)
+        {
+            if (!PdfName.Figure.Equals(structElem.GetAsName(PdfName.S)))
+            {
+                continue;
+            }
+
+            var alt = structElem.GetAsString(PdfName.Alt)?.ToUnicodeString();
+            if (string.IsNullOrWhiteSpace(alt))
+            {
+                continue;
+            }
+
+            var kids = structElem.Get(PdfName.K);
+            if (kids is not null)
+            {
+                CollectInlineFigureAltTextKids(kids, alt.Trim(), altByMcid, new HashSet<(int objNum, int genNum)>());
+            }
+        }
+
+        return altByMcid;
+    }
+
+    private static void CollectInlineFigureAltTextKids(
+        PdfObject node,
+        string alt,
+        Dictionary<int, string> altByMcid,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        node = Dereference(node, visited);
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                CollectInlineFigureAltTextKids(item, alt, altByMcid, visited);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        var mcid = dict.GetAsNumber(PdfName.MCID)?.IntValue();
+        if (mcid is not null)
+        {
+            altByMcid.TryAdd(mcid.Value, alt);
+            return;
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            CollectInlineFigureAltTextKids(kids, alt, altByMcid, visited);
+        }
+    }
+
+    private static bool ContainsDictionaryKey(string dictionaryContent, string key)
+        => Regex.IsMatch(
+            dictionaryContent,
+            $@"/{Regex.Escape(key)}(?:\s|/|<|\(|\[|$)",
+            RegexOptions.CultureInvariant);
+
+    private static string ToPdfTextStringHex(string text)
+    {
+        var bytes = Encoding.BigEndianUnicode.GetBytes(text);
+        return "FEFF" + Convert.ToHexString(bytes);
+    }
+
+    private static void CollectParentTreeClaimStructElements(
+        PdfObject value,
+        List<PdfDictionary> structElems,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        value = Dereference(value, visited);
+
+        if (value is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                CollectParentTreeClaimStructElements(item, structElems, visited);
+            }
+
+            return;
+        }
+
+        if (value is PdfDictionary dict)
+        {
+            structElems.Add(dict);
+        }
+    }
+
+    private static bool IsMeaningfulStructureElement(PdfDictionary dict)
+    {
+        var role = dict.GetAsName(PdfName.S);
+        if (role is null)
+        {
+            return false;
+        }
+
+        if (PdfName.Figure.Equals(role)
+            || PdfName.Link.Equals(role)
+            || PdfName.Form.Equals(role)
+            || RoleAnnot.Equals(role)
+            || RoleFormula.Equals(role))
+        {
+            return true;
+        }
+
+        var alt = dict.GetAsString(PdfName.Alt)?.ToUnicodeString();
+        return !string.IsNullOrWhiteSpace(alt);
+    }
+
+    private static PdfDictionary? TryGetParentTree(PdfDocument pdf)
+    {
+        var catalogDict = pdf.GetCatalog().GetPdfObject();
+        var structTreeRootDict = catalogDict.GetAsDictionary(PdfName.StructTreeRoot);
+        return structTreeRootDict?.GetAsDictionary(PdfName.ParentTree);
+    }
+
+    private static PdfObject? TryGetNumberTreeValue(PdfDictionary numberTree, int key)
+    {
+        return TryGetNumberTreeValueRecursive(numberTree, key, new HashSet<(int objNum, int genNum)>());
+    }
+
+    private static PdfObject? TryGetNumberTreeValueRecursive(
+        PdfDictionary node,
+        int key,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        var nodeRef = node.GetIndirectReference();
+        if (nodeRef is not null)
+        {
+            var nodeKey = (nodeRef.GetObjNumber(), nodeRef.GetGenNumber());
+            if (!visited.Add(nodeKey))
+            {
+                return null;
+            }
+        }
+
+        var nums = node.GetAsArray(PdfName.Nums);
+        if (nums is not null)
+        {
+            for (var i = 0; i + 1 < nums.Size(); i += 2)
+            {
+                if (nums.GetAsNumber(i)?.IntValue() == key)
+                {
+                    return nums.Get(i + 1);
+                }
+            }
+
+            return null;
+        }
+
+        var kids = node.GetAsArray(PdfName.Kids);
+        if (kids is null)
+        {
+            return null;
+        }
+
+        for (var i = 0; i < kids.Size(); i++)
+        {
+            var kidObj = Dereference(kids.Get(i));
+            if (kidObj is not PdfDictionary kidDict)
+            {
+                continue;
+            }
+
+            var limits = kidDict.GetAsArray(PdfName.Limits);
+            if (limits is not null && limits.Size() >= 2)
+            {
+                var low = limits.GetAsNumber(0)?.IntValue();
+                var high = limits.GetAsNumber(1)?.IntValue();
+                if (low is not null && high is not null && (key < low.Value || key > high.Value))
+                {
+                    continue;
+                }
+            }
+
+            var value = TryGetNumberTreeValueRecursive(kidDict, key, visited);
+            if (value is not null)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static PdfObject Dereference(PdfObject obj)
+    {
+        return obj is PdfIndirectReference reference
+            ? reference.GetRefersTo(true) ?? new PdfNull()
+            : obj;
+    }
+
+    private static PdfObject Dereference(PdfObject obj, HashSet<(int objNum, int genNum)> visited)
+    {
+        if (obj is not PdfIndirectReference reference)
+        {
+            return obj;
+        }
+
+        var key = (reference.GetObjNumber(), reference.GetGenNumber());
+        if (!visited.Add(key))
+        {
+            return new PdfNull();
+        }
+
+        return reference.GetRefersTo(true) ?? new PdfNull();
+    }
+
+    private sealed record ParentTreeClaimAnalysis(
+        bool IsProtected,
+        IReadOnlyList<PdfDictionary> StructElements)
+    {
+        public static ParentTreeClaimAnalysis Unclaimed { get; } = new(
+            IsProtected: false,
+            StructElements: Array.Empty<PdfDictionary>());
+
+        public static ParentTreeClaimAnalysis ProtectedClaim(IReadOnlyList<PdfDictionary> structElements)
+            => new(IsProtected: true, StructElements: structElements);
+    }
+}

--- a/tests/server.tests/Integration/Remediate/PdfXObjectStructureAssociationRemediatorTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfXObjectStructureAssociationRemediatorTests.cs
@@ -1,0 +1,682 @@
+using System.Text;
+using FluentAssertions;
+using iText.IO.Font;
+using iText.Kernel.Pdf;
+using server.core.Remediate;
+
+namespace server.tests.Integration.Remediate;
+
+public sealed class PdfXObjectStructureAssociationRemediatorTests
+{
+    private static readonly PdfName RoleOther = new("Other");
+    private static readonly PdfName RoleFormula = new("Formula");
+    private static readonly PdfName StructParentsKey = new("StructParents");
+
+    [Fact]
+    public void Remediate_UnclaimedFormXObjectWithStructParents_DisconnectsAssociation()
+    {
+        var runRoot = CreateRunRoot("remediate-xobject-form");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateTaggedPdfWithXObjectStructParents(inputPdfPath, PdfName.Form, RoleOther);
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.Inspected.Should().Be(2);
+            result.Protected.Should().Be(0);
+            result.Disconnected.Should().Be(1);
+            CountXObjectsWithStructParents(outputPdfPath).Should().Be(0);
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    [Fact]
+    public void Remediate_UnclaimedImageXObjectWithStructParents_DisconnectsAssociation()
+    {
+        var runRoot = CreateRunRoot("remediate-xobject-image");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateTaggedPdfWithXObjectStructParents(inputPdfPath, PdfName.Image, RoleOther);
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.Inspected.Should().Be(1);
+            result.Protected.Should().Be(0);
+            result.Disconnected.Should().Be(1);
+            CountXObjectsWithStructParents(outputPdfPath).Should().Be(0);
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    [Fact]
+    public void Remediate_FigureClaimedXObject_PreservesAssociationEvenWhenAltIsMissing()
+    {
+        var runRoot = CreateRunRoot("remediate-xobject-figure");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateTaggedPdfWithXObjectStructParents(inputPdfPath, PdfName.Form, PdfName.Figure);
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.Inspected.Should().Be(2);
+            result.Protected.Should().Be(1);
+            result.Disconnected.Should().Be(0);
+            CountXObjectsWithStructParents(outputPdfPath).Should().Be(1);
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    [Fact]
+    public void Remediate_AlreadyRemediatedFigureClaimedXObject_PreservesAssociation()
+    {
+        var runRoot = CreateRunRoot("remediate-xobject-figure-alt");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateTaggedPdfWithXObjectStructParents(inputPdfPath, PdfName.Form, PdfName.Figure, "Existing figure alt text");
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.Inspected.Should().Be(2);
+            result.Protected.Should().Be(1);
+            result.Disconnected.Should().Be(0);
+            CountXObjectsWithStructParents(outputPdfPath).Should().Be(1);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            ListStructElementsByRole(outputPdf, PdfName.Figure)
+                .Should()
+                .ContainSingle(f => GetAlt(f) == "Existing figure alt text");
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    [Fact]
+    public void Remediate_FormBackedFigureMcrMissingPage_AddsPageToMarkedContentReference()
+    {
+        var runRoot = CreateRunRoot("remediate-xobject-mcr-page");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateTaggedPdfWithFormBackedFigureMcrMissingPage(inputPdfPath);
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.InlineAltApplied.Should().Be(1);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            var figure = ListStructElementsByRole(outputPdf, PdfName.Figure).Should().ContainSingle().Subject;
+            var mcr = figure.GetAsArray(PdfName.K)!.GetAsDictionary(0)!;
+
+            mcr.GetAsNumber(PdfName.MCID)!.IntValue().Should().Be(0);
+            mcr.GetAsDictionary(PdfName.Pg).Should().NotBeNull("Form-backed MCRs need explicit page context for Acrobat to resolve the Structure Tag");
+            mcr.Get(PdfName.Stm).Should().NotBeNull();
+            GetFormXObjectContent(outputPdf)
+                .Should()
+                .Contain("/Alt <FEFF", "Acrobat checks Form XObject inline Figure marked content for alt text separately from the tag-tree Figure /Alt");
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MeaningfulClaims))]
+    public void Remediate_MeaningfullyClaimedXObject_PreservesAssociation(PdfName role, string? alt)
+    {
+        var runRoot = CreateRunRoot($"remediate-xobject-claimed-{role.GetValue()}");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateTaggedPdfWithXObjectStructParents(inputPdfPath, PdfName.Image, role, alt);
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.Protected.Should().Be(1);
+            result.Disconnected.Should().Be(0);
+            CountXObjectsWithStructParents(outputPdfPath).Should().Be(1);
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    [Fact]
+    public void Remediate_UntaggedPdf_DoesNothing()
+    {
+        var runRoot = CreateRunRoot("remediate-xobject-untagged");
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            CreateUntaggedPdfWithXObjectStructParents(inputPdfPath);
+
+            PdfXObjectStructureAssociationRemediationResult result;
+            using (var pdf = new PdfDocument(new PdfReader(inputPdfPath), new PdfWriter(outputPdfPath)))
+            {
+                result = PdfXObjectStructureAssociationRemediator.Remediate(pdf, CancellationToken.None);
+            }
+
+            result.Should().Be(new PdfXObjectStructureAssociationRemediationResult(0, 0, 0));
+            CountXObjectsWithStructParents(outputPdfPath).Should().Be(1);
+        }
+        finally
+        {
+            DeleteRunRoot(runRoot);
+        }
+    }
+
+    public static TheoryData<PdfName, string?> MeaningfulClaims()
+    {
+        return new TheoryData<PdfName, string?>
+        {
+            { RoleOther, "Meaningful alternate text" },
+            { PdfName.Link, null },
+            { PdfName.Form, null },
+            { RoleFormula, null },
+        };
+    }
+
+    private static void CreateTaggedPdfWithXObjectStructParents(
+        string outputPath,
+        PdfName xObjectSubtype,
+        PdfName claimRole,
+        string? claimAlt = null)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        using var pdf = new PdfDocument(new PdfWriter(outputPath));
+        var page = pdf.AddNewPage();
+        AddXObjectWithStructParents(pdf, page, xObjectSubtype);
+        AddTagTreeWithParentTreeClaim(pdf, claimRole, claimAlt);
+    }
+
+    private static void CreateUntaggedPdfWithXObjectStructParents(string outputPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        using var pdf = new PdfDocument(new PdfWriter(outputPath));
+        var page = pdf.AddNewPage();
+        AddXObjectWithStructParents(pdf, page, PdfName.Form);
+    }
+
+    private static void CreateTaggedPdfWithFormBackedFigureMcrMissingPage(string outputPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        using var pdf = new PdfDocument(new PdfWriter(outputPath));
+        var page = pdf.AddNewPage();
+
+        var resources = new PdfDictionary();
+        resources.MakeIndirect(pdf);
+        var xObjects = new PdfDictionary();
+        resources.Put(PdfName.XObject, xObjects);
+        page.GetPdfObject().Put(PdfName.Resources, resources);
+
+        var form = new PdfStream(Encoding.ASCII.GetBytes("/Figure <</MCID 0 >> BDC /Im0 Do EMC"));
+        form.MakeIndirect(pdf);
+        form.Put(PdfName.Type, PdfName.XObject);
+        form.Put(PdfName.Subtype, PdfName.Form);
+        form.Put(PdfName.BBox, new PdfArray(new[] { 0, 0, 10, 10 }));
+        form.Put(StructParentsKey, new PdfNumber(0));
+        xObjects.Put(new PdfName("Fm0"), form.GetIndirectReference());
+
+        var catalog = pdf.GetCatalog().GetPdfObject();
+        var structTreeRoot = new PdfDictionary();
+        structTreeRoot.MakeIndirect(pdf);
+        structTreeRoot.Put(PdfName.Type, PdfName.StructTreeRoot);
+
+        var parentTree = new PdfDictionary();
+        parentTree.MakeIndirect(pdf);
+        structTreeRoot.Put(PdfName.ParentTree, parentTree);
+
+        var documentElem = new PdfDictionary();
+        documentElem.MakeIndirect(pdf);
+        documentElem.Put(PdfName.Type, new PdfName("StructElem"));
+        documentElem.Put(PdfName.S, new PdfName("Document"));
+        documentElem.Put(PdfName.P, structTreeRoot);
+
+        var figure = new PdfDictionary();
+        figure.MakeIndirect(pdf);
+        figure.Put(PdfName.Type, new PdfName("StructElem"));
+        figure.Put(PdfName.S, PdfName.Figure);
+        figure.Put(PdfName.P, documentElem);
+        figure.Put(PdfName.Pg, page.GetPdfObject());
+        figure.Put(PdfName.Alt, new PdfString("Existing figure alt text", PdfEncodings.UNICODE_BIG));
+
+        var mcr = new PdfDictionary();
+        mcr.Put(PdfName.Type, new PdfName("MCR"));
+        mcr.Put(PdfName.MCID, new PdfNumber(0));
+        mcr.Put(PdfName.Stm, form.GetIndirectReference());
+        figure.Put(PdfName.K, new PdfArray(mcr));
+
+        var documentKids = new PdfArray();
+        documentKids.Add(figure);
+        documentElem.Put(PdfName.K, documentKids);
+        structTreeRoot.Put(PdfName.K, documentElem);
+
+        var nums = new PdfArray();
+        nums.Add(new PdfNumber(0));
+        nums.Add(new PdfArray(figure));
+        parentTree.Put(PdfName.Nums, nums);
+
+        var markInfo = new PdfDictionary();
+        markInfo.MakeIndirect(pdf);
+        markInfo.Put(PdfName.Marked, PdfBoolean.ValueOf(true));
+
+        catalog.Put(PdfName.MarkInfo, markInfo);
+        catalog.Put(PdfName.StructTreeRoot, structTreeRoot);
+    }
+
+    private static void AddXObjectWithStructParents(PdfDocument pdf, PdfPage page, PdfName subtype)
+    {
+        var resources = new PdfDictionary();
+        resources.MakeIndirect(pdf);
+
+        var xObjects = new PdfDictionary();
+        resources.Put(PdfName.XObject, xObjects);
+        page.GetPdfObject().Put(PdfName.Resources, resources);
+
+        var xObject = PdfName.Image.Equals(subtype)
+            ? new PdfStream(new byte[] { 0, 0, 0 })
+            : new PdfStream(Array.Empty<byte>());
+
+        xObject.MakeIndirect(pdf);
+        xObject.Put(PdfName.Type, PdfName.XObject);
+        xObject.Put(PdfName.Subtype, subtype);
+        xObject.Put(StructParentsKey, new PdfNumber(0));
+
+        if (PdfName.Image.Equals(subtype))
+        {
+            xObject.Put(PdfName.Width, new PdfNumber(1));
+            xObject.Put(PdfName.Height, new PdfNumber(1));
+            xObject.Put(PdfName.ColorSpace, PdfName.DeviceRGB);
+            xObject.Put(PdfName.BitsPerComponent, new PdfNumber(8));
+        }
+        else
+        {
+            xObject.Put(PdfName.BBox, new PdfArray(new[] { 0, 0, 10, 10 }));
+        }
+
+        xObjects.Put(new PdfName("XO1"), xObject.GetIndirectReference());
+
+        if (PdfName.Form.Equals(subtype))
+        {
+            var nestedResources = new PdfDictionary();
+            nestedResources.MakeIndirect(pdf);
+
+            var nestedXObjects = new PdfDictionary();
+            nestedResources.Put(PdfName.XObject, nestedXObjects);
+            xObject.Put(PdfName.Resources, nestedResources);
+
+            var image = new PdfStream(new byte[] { 0, 0, 0 });
+            image.MakeIndirect(pdf);
+            image.Put(PdfName.Type, PdfName.XObject);
+            image.Put(PdfName.Subtype, PdfName.Image);
+            image.Put(PdfName.Width, new PdfNumber(1));
+            image.Put(PdfName.Height, new PdfNumber(1));
+            image.Put(PdfName.ColorSpace, PdfName.DeviceRGB);
+            image.Put(PdfName.BitsPerComponent, new PdfNumber(8));
+            nestedXObjects.Put(new PdfName("Im0"), image.GetIndirectReference());
+        }
+    }
+
+    private static void AddTagTreeWithParentTreeClaim(PdfDocument pdf, PdfName claimRole, string? claimAlt)
+    {
+        var catalog = pdf.GetCatalog().GetPdfObject();
+
+        var structTreeRoot = new PdfDictionary();
+        structTreeRoot.MakeIndirect(pdf);
+        structTreeRoot.Put(PdfName.Type, PdfName.StructTreeRoot);
+
+        var parentTree = new PdfDictionary();
+        parentTree.MakeIndirect(pdf);
+        structTreeRoot.Put(PdfName.ParentTree, parentTree);
+
+        var documentElem = new PdfDictionary();
+        documentElem.MakeIndirect(pdf);
+        documentElem.Put(PdfName.Type, new PdfName("StructElem"));
+        documentElem.Put(PdfName.S, new PdfName("Document"));
+        documentElem.Put(PdfName.P, structTreeRoot);
+
+        var claimedElem = new PdfDictionary();
+        claimedElem.MakeIndirect(pdf);
+        claimedElem.Put(PdfName.Type, new PdfName("StructElem"));
+        claimedElem.Put(PdfName.S, claimRole);
+        claimedElem.Put(PdfName.P, documentElem);
+        if (claimAlt is not null)
+        {
+            claimedElem.Put(PdfName.Alt, new PdfString(claimAlt, PdfEncodings.UNICODE_BIG));
+        }
+
+        var documentKids = new PdfArray();
+        documentKids.Add(claimedElem);
+        documentElem.Put(PdfName.K, documentKids);
+        structTreeRoot.Put(PdfName.K, documentElem);
+
+        var parentTreeEntry = new PdfArray();
+        parentTreeEntry.Add(claimedElem);
+
+        var nums = new PdfArray();
+        nums.Add(new PdfNumber(0));
+        nums.Add(parentTreeEntry);
+        parentTree.Put(PdfName.Nums, nums);
+
+        var markInfo = new PdfDictionary();
+        markInfo.MakeIndirect(pdf);
+        markInfo.Put(PdfName.Marked, PdfBoolean.ValueOf(true));
+
+        catalog.Put(PdfName.MarkInfo, markInfo);
+        catalog.Put(PdfName.StructTreeRoot, structTreeRoot);
+    }
+
+    private static int CountXObjectsWithStructParents(string pdfPath)
+    {
+        using var pdf = new PdfDocument(new PdfReader(pdfPath));
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var count = 0;
+
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            count += CountXObjectsWithStructParents(pdf.GetPage(pageNumber).GetResources()?.GetPdfObject(), visited);
+        }
+
+        return count;
+    }
+
+    private static int CountFormFigureMarkedContentWithoutInlineAlt(string pdfPath)
+    {
+        using var pdf = new PdfDocument(new PdfReader(pdfPath));
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var count = 0;
+
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            count += CountFormFigureMarkedContentWithoutInlineAlt(
+                pdf.GetPage(pageNumber).GetResources()?.GetPdfObject(),
+                visited);
+        }
+
+        return count;
+    }
+
+    private static int CountFormFigureMarkedContentWithoutInlineAlt(
+        PdfDictionary? resources,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        var xObjects = resources?.GetAsDictionary(PdfName.XObject);
+        if (xObjects is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var name in xObjects.KeySet())
+        {
+            var obj = xObjects.Get(name);
+            if (obj is null || obj is PdfNull)
+            {
+                continue;
+            }
+
+            var objRef = obj as PdfIndirectReference ?? obj.GetIndirectReference();
+            if (objRef is not null && !visited.Add((objRef.GetObjNumber(), objRef.GetGenNumber())))
+            {
+                continue;
+            }
+
+            obj = obj is PdfIndirectReference reference ? reference.GetRefersTo(true) : obj;
+            if (obj is not PdfStream stream || !PdfName.Form.Equals(stream.GetAsName(PdfName.Subtype)))
+            {
+                continue;
+            }
+
+            var content = Encoding.Latin1.GetString(stream.GetBytes());
+            if (content.Contains("/Figure", StringComparison.Ordinal)
+                && content.Contains("BDC", StringComparison.Ordinal)
+                && !content.Contains("/Alt", StringComparison.Ordinal))
+            {
+                count++;
+            }
+
+            count += CountFormFigureMarkedContentWithoutInlineAlt(stream.GetAsDictionary(PdfName.Resources), visited);
+        }
+
+        return count;
+    }
+
+    private static int CountImageXObjectsWithAlt(string pdfPath)
+    {
+        using var pdf = new PdfDocument(new PdfReader(pdfPath));
+        var visited = new HashSet<(int objNum, int genNum)>();
+        var count = 0;
+
+        for (var pageNumber = 1; pageNumber <= pdf.GetNumberOfPages(); pageNumber++)
+        {
+            count += CountImageXObjectsWithAlt(pdf.GetPage(pageNumber).GetResources()?.GetPdfObject(), visited);
+        }
+
+        return count;
+    }
+
+    private static int CountImageXObjectsWithAlt(
+        PdfDictionary? resources,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        var xObjects = resources?.GetAsDictionary(PdfName.XObject);
+        if (xObjects is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var name in xObjects.KeySet())
+        {
+            var obj = xObjects.Get(name);
+            if (obj is null || obj is PdfNull)
+            {
+                continue;
+            }
+
+            var objRef = obj as PdfIndirectReference ?? obj.GetIndirectReference();
+            if (objRef is not null && !visited.Add((objRef.GetObjNumber(), objRef.GetGenNumber())))
+            {
+                continue;
+            }
+
+            obj = obj is PdfIndirectReference reference ? reference.GetRefersTo(true) : obj;
+            if (obj is not PdfStream stream)
+            {
+                continue;
+            }
+
+            if (PdfName.Image.Equals(stream.GetAsName(PdfName.Subtype))
+                && !string.IsNullOrWhiteSpace(stream.GetAsString(PdfName.Alt)?.ToUnicodeString()))
+            {
+                count++;
+            }
+
+            if (PdfName.Form.Equals(stream.GetAsName(PdfName.Subtype)))
+            {
+                count += CountImageXObjectsWithAlt(stream.GetAsDictionary(PdfName.Resources), visited);
+            }
+        }
+
+        return count;
+    }
+
+    private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
+    {
+        var results = new List<PdfDictionary>();
+        var rootKids = pdf.GetCatalog().GetPdfObject().GetAsDictionary(PdfName.StructTreeRoot)?.Get(PdfName.K);
+        if (rootKids is not null)
+        {
+            TraverseStructElements(rootKids, role, results);
+        }
+
+        return results;
+    }
+
+    private static void TraverseStructElements(PdfObject node, PdfName role, List<PdfDictionary> results)
+    {
+        node = node is PdfIndirectReference reference ? reference.GetRefersTo(true) : node;
+
+        if (node is PdfArray array)
+        {
+            foreach (var item in array)
+            {
+                TraverseStructElements(item, role, results);
+            }
+
+            return;
+        }
+
+        if (node is not PdfDictionary dict)
+        {
+            return;
+        }
+
+        if (role.Equals(dict.GetAsName(PdfName.S)))
+        {
+            results.Add(dict);
+        }
+
+        var kids = dict.Get(PdfName.K);
+        if (kids is not null)
+        {
+            TraverseStructElements(kids, role, results);
+        }
+    }
+
+    private static string? GetAlt(PdfDictionary structElem)
+        => structElem.GetAsString(PdfName.Alt)?.ToUnicodeString();
+
+    private static string GetFormXObjectContent(PdfDocument pdf)
+    {
+        var xObjects = pdf.GetPage(1).GetResources().GetPdfObject().GetAsDictionary(PdfName.XObject)!;
+        var formObject = xObjects.Get(new PdfName("Fm0"));
+        var form = formObject is PdfIndirectReference reference
+            ? (PdfStream)reference.GetRefersTo(true)
+            : (PdfStream)formObject;
+        return Encoding.Latin1.GetString(form.GetBytes());
+    }
+
+    private static int CountXObjectsWithStructParents(
+        PdfDictionary? resources,
+        HashSet<(int objNum, int genNum)> visited)
+    {
+        var xObjects = resources?.GetAsDictionary(PdfName.XObject);
+        if (xObjects is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var name in xObjects.KeySet())
+        {
+            var obj = xObjects.Get(name);
+            if (obj is null || obj is PdfNull)
+            {
+                continue;
+            }
+
+            var objRef = obj as PdfIndirectReference ?? obj.GetIndirectReference();
+            if (objRef is not null && !visited.Add((objRef.GetObjNumber(), objRef.GetGenNumber())))
+            {
+                continue;
+            }
+
+            obj = obj is PdfIndirectReference reference ? reference.GetRefersTo(true) : obj;
+            if (obj is not PdfStream stream)
+            {
+                continue;
+            }
+
+            var subtype = stream.GetAsName(PdfName.Subtype);
+            if (!PdfName.Form.Equals(subtype) && !PdfName.Image.Equals(subtype))
+            {
+                continue;
+            }
+
+            if (stream.GetAsNumber(StructParentsKey) is not null)
+            {
+                count++;
+            }
+
+            if (PdfName.Form.Equals(subtype))
+            {
+                count += CountXObjectsWithStructParents(stream.GetAsDictionary(PdfName.Resources), visited);
+            }
+        }
+
+        return count;
+    }
+
+    private static string CreateRunRoot(string name)
+    {
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+        return runRoot;
+    }
+
+    private static void DeleteRunRoot(string runRoot)
+    {
+        if (Directory.Exists(runRoot))
+        {
+            Directory.Delete(runRoot, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an XObject structure association remediation pass for tagged PDFs
- preserve meaningful XObject claims while disconnecting unclaimed structure residue
- mirror tag-tree Figure alt text into Form XObject inline /Figure marked content so Adobe no longer reports Other elements alternate text failures

## Verification
- dotnet build
- dotnet test
- Adobe PDF Services checker on /tmp/readable-full-pipeline-v1/MajorBrochure_2023_XObject.remediated.pdf: Failed = 0, Other elements alternate text = Passed

## Notes
The MajorBrochure source fixture is not currently tracked in the repo, so the committed regression tests use synthetic tagged PDFs for the Form XObject-backed Figure cases. The real MajorBrochure output was still verified locally with Adobe PDF Services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PDF remediation to properly handle structure associations for embedded form and image elements, ensuring alt text is correctly applied and unnecessary associations are removed.

* **Tests**
  * Added integration tests for the enhanced PDF remediation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/readable/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->