### PR TITLE
Fix decorative stroked figure demotion

### DIFF
--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -2030,6 +2030,15 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     return null;
                 }
 
+                var strokeExpansion = GetStrokeExpansion(pathRenderInfo);
+                if (strokeExpansion > 0)
+                {
+                    minX -= strokeExpansion;
+                    minY -= strokeExpansion;
+                    maxX += strokeExpansion;
+                    maxY += strokeExpansion;
+                }
+
                 return new Rectangle((float)minX, (float)minY, (float)(maxX - minX), (float)(maxY - minY));
             }
 
@@ -2067,6 +2076,32 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                 minY = Math.Min(minY, ty);
                 maxX = Math.Max(maxX, tx);
                 maxY = Math.Max(maxY, ty);
+            }
+
+            private static double GetStrokeExpansion(PathRenderInfo pathRenderInfo)
+            {
+                if ((pathRenderInfo.GetOperation() & PathRenderInfo.STROKE) == 0)
+                {
+                    return 0;
+                }
+
+                var lineWidth = pathRenderInfo.GetLineWidth();
+                var ctm = pathRenderInfo.GetCtm();
+
+                var a = ctm.Get(iText.Kernel.Geom.Matrix.I11);
+                var b = ctm.Get(iText.Kernel.Geom.Matrix.I12);
+                var c = ctm.Get(iText.Kernel.Geom.Matrix.I21);
+                var d = ctm.Get(iText.Kernel.Geom.Matrix.I22);
+                var xScale = Math.Sqrt((a * a) + (b * b));
+                var yScale = Math.Sqrt((c * c) + (d * d));
+                var scale = Math.Max(xScale, yScale);
+                if (scale <= 0)
+                {
+                    scale = 1;
+                }
+
+                var visualLineWidth = lineWidth > 0 ? lineWidth * scale : 0.5;
+                return visualLineWidth / 2d;
             }
 
             private record struct PendingVectorFigure(Rectangle Bounds, int TextCharIndex);

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorDecorativeFigureTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorDecorativeFigureTests.cs
@@ -96,6 +96,48 @@ public sealed class PdfRemediationProcessorDecorativeFigureTests
         }
     }
 
+    [Fact]
+    public async Task ProcessAsync_StrokedHorizontalRuleFigure_DemotesWithoutCallingAltTextService()
+    {
+        var runRoot = Path.Combine(Path.GetTempPath(), "readable-tests", $"remediate-vector-rule-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateTaggedPdfWithHorizontalRuleFigure(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+
+            var altText = new FakeAltTextService();
+            var sut = new PdfRemediationProcessor(
+                altText,
+                new NoopPdfBookmarkService(),
+                new FakePdfTitleService(),
+                new DetailPdfPageRasterizer(),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "fixture",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            using var outputPdf = new PdfDocument(new PdfReader(outputPdfPath));
+            var outputFigures = ListStructElementsByRole(outputPdf, PdfName.Figure);
+
+            outputFigures.Should().BeEmpty("stroked decorative rules should be demoted instead of left as figures missing alt text");
+            altText.ImageCalls.Should().Be(0);
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
     private static void CreateTaggedPdfWithPlaceholderVectorFigure(
         string outputPath,
         float figureWidth = 120,
@@ -161,6 +203,74 @@ public sealed class PdfRemediationProcessorDecorativeFigureTests
         canvas.SetFillColor(ColorConstants.BLACK);
         canvas.Rectangle(100, 500, figureWidth, figureHeight);
         canvas.Fill();
+        canvas.RestoreState();
+        canvas.EndMarkedContent();
+        canvas.Release();
+    }
+
+    private static void CreateTaggedPdfWithHorizontalRuleFigure(string outputPath)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        const int mcid = 0;
+
+        using var pdf = new PdfDocument(new PdfWriter(outputPath));
+        var page = pdf.AddNewPage();
+        var pageDict = page.GetPdfObject();
+
+        var catalog = pdf.GetCatalog().GetPdfObject();
+
+        var structTreeRoot = new PdfDictionary();
+        structTreeRoot.MakeIndirect(pdf);
+        structTreeRoot.Put(PdfName.Type, PdfName.StructTreeRoot);
+
+        var parentTree = new PdfDictionary();
+        parentTree.MakeIndirect(pdf);
+        structTreeRoot.Put(PdfName.ParentTree, parentTree);
+
+        var documentElem = new PdfDictionary();
+        documentElem.MakeIndirect(pdf);
+        documentElem.Put(PdfName.Type, new PdfName("StructElem"));
+        documentElem.Put(PdfName.S, new PdfName("Document"));
+        documentElem.Put(PdfName.P, structTreeRoot);
+
+        var figureElem = new PdfDictionary();
+        figureElem.MakeIndirect(pdf);
+        figureElem.Put(PdfName.Type, new PdfName("StructElem"));
+        figureElem.Put(PdfName.S, PdfName.Figure);
+        figureElem.Put(PdfName.P, documentElem);
+        figureElem.Put(PdfName.Pg, pageDict);
+
+        var markedContentRef = new PdfDictionary();
+        markedContentRef.Put(PdfName.Type, new PdfName("MCR"));
+        markedContentRef.Put(PdfName.Pg, pageDict);
+        markedContentRef.Put(PdfName.MCID, new PdfNumber(mcid));
+        figureElem.Put(PdfName.K, markedContentRef);
+
+        var kids = new PdfArray();
+        kids.Add(figureElem);
+        documentElem.Put(PdfName.K, kids);
+
+        structTreeRoot.Put(PdfName.K, documentElem);
+
+        var markInfo = new PdfDictionary();
+        markInfo.MakeIndirect(pdf);
+        markInfo.Put(PdfName.Marked, PdfBoolean.ValueOf(true));
+
+        catalog.Put(PdfName.MarkInfo, markInfo);
+        catalog.Put(PdfName.StructTreeRoot, structTreeRoot);
+
+        var markedContentProperties = new PdfDictionary();
+        markedContentProperties.Put(PdfName.MCID, new PdfNumber(mcid));
+
+        var canvas = new PdfCanvas(page);
+        canvas.BeginMarkedContent(PdfName.Figure, markedContentProperties);
+        canvas.SaveState();
+        canvas.SetStrokeColor(ColorConstants.BLACK);
+        canvas.SetLineWidth(1);
+        canvas.MoveTo(72, 500);
+        canvas.LineTo(540, 500);
+        canvas.Stroke();
         canvas.RestoreState();
         canvas.EndMarkedContent();
         canvas.Release();


### PR DESCRIPTION
## Summary
- include stroked path width when computing vector figure bounds
- allow horizontal/vertical decorative rules tagged as figures to be demoted instead of remaining figures without alt text
- add synthetic regression coverage for a tagged stroked horizontal rule

## Verification
- dotnet test tests/server.tests/server.tests.csproj --filter "FullyQualifiedName~PdfRemediationProcessorDecorativeFigureTests|FullyQualifiedName~PdfRemediationProcessorVectorFigureAltTests"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * More accurate vector-figure bounds detection in PDF remediation by accounting for stroke width, improving identification of stroked graphic elements.

* **Bug Fixes**
  * Enhanced handling of decorative vector figures so stroked lines are demoted/removed without producing unnecessary alt-text.

* **Tests**
  * Added integration tests to validate correct treatment of decorative stroked figures and that alt-text generation is not invoked unnecessarily.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/readable/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->