### PR TITLE
Fix ODL image placeholder alt remediation

### DIFF
--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -1492,7 +1492,8 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
     private static bool IsPlaceholderImageAltText(string altText)
     {
         altText = RemediationHelpers.NormalizeWhitespace(altText);
-        return string.Equals(altText, PlaceholderImageAltText, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(altText, PlaceholderImageAltText, StringComparison.OrdinalIgnoreCase)
+            || IsNumberedImagePlaceholderAltText(altText);
     }
 
     private static bool IsMeaningfulImageAltText(string altText)
@@ -1500,6 +1501,32 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
     private static bool ShouldGenerateAltForFigure(PdfDictionary figure)
         => !HasNonEmptyAlt(figure) || HasPlaceholderAlt(figure);
+
+    private static bool IsNumberedImagePlaceholderAltText(string altText)
+    {
+        const string prefix = "image ";
+
+        if (!altText.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var number = altText.AsSpan(prefix.Length);
+        if (number.IsEmpty)
+        {
+            return false;
+        }
+
+        foreach (var ch in number)
+        {
+            if (!char.IsAsciiDigit(ch))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Writes an <c>/Alt</c> entry to a structure element if the provided text is non-empty.

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorVectorFigureAltTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorVectorFigureAltTests.cs
@@ -54,6 +54,7 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
             var outputPlaceholderCount = outputFigures.Count(f => IsPlaceholderAlt(f));
 
             outputPlaceholderCount.Should().BeLessThan(inputPlaceholderCount, "vector figure remediation should reduce placeholder alt text");
+            outputFigures.Should().Contain(f => GetAlt(f) == "generated alt text");
             altText.ImageCalls.Should().BeGreaterThan(0, "vector figure remediation should call the alt text service at least once");
         }
         finally
@@ -97,7 +98,7 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
         figureElem.Put(PdfName.S, PdfName.Figure);
         figureElem.Put(PdfName.P, documentElem);
         figureElem.Put(PdfName.Pg, pageDict);
-        figureElem.Put(PdfName.Alt, new PdfString("alt text for image", PdfEncodings.UNICODE_BIG));
+        figureElem.Put(PdfName.Alt, new PdfString("image 3", PdfEncodings.UNICODE_BIG));
 
         var markedContentRef = new PdfDictionary();
         markedContentRef.Put(PdfName.Type, new PdfName("MCR"));
@@ -216,9 +217,12 @@ public sealed class PdfRemediationProcessorVectorFigureAltTests
 
     private static bool IsPlaceholderAlt(PdfDictionary structElem)
     {
-        var alt = structElem.GetAsString(PdfName.Alt)?.ToUnicodeString() ?? string.Empty;
-        return string.Equals(alt.Trim(), "alt text for image", StringComparison.OrdinalIgnoreCase);
+        var alt = GetAlt(structElem)?.Trim() ?? string.Empty;
+        return string.Equals(alt, "alt text for image", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(alt, "image 3", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static string? GetAlt(PdfDictionary structElem) => structElem.GetAsString(PdfName.Alt)?.ToUnicodeString();
 
     private static List<PdfDictionary> ListStructElementsByRole(PdfDocument pdf, PdfName role)
     {


### PR DESCRIPTION
## Summary
- Treat ODL-style numbered image alt text like `image 3` as placeholder text
- Regenerate placeholder figure alt text instead of skipping it as non-empty
- Add regression coverage for replacing an `image 3` figure alt value

## Verification
- `dotnet build app.sln`
- `dotnet test tests/server.tests/server.tests.csproj`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placeholder image alt text detection to recognize numbered patterns (e.g., "image 1", "image 2"). This enables the PDF remediation process to better identify and replace numbered placeholder text with meaningful, accessible descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/readable/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->