### PR TITLE
Migrate PDF remediation to Responses API

### DIFF
--- a/server.core/Remediate/AltText/OpenAIAltTextService.cs
+++ b/server.core/Remediate/AltText/OpenAIAltTextService.cs
@@ -1,26 +1,39 @@
-using System.ClientModel;
+#pragma warning disable OPENAI001
+
 using System.Text;
-using OpenAI.Chat;
+using OpenAI.Responses;
 
 namespace server.core.Remediate.AltText;
 
 public sealed class OpenAIAltTextService : IAltTextService
 {
-    private readonly ChatClient _chatClient;
+    private readonly IOpenAIResponseGenerationClient _client;
+    private readonly string _model;
 
     public OpenAIAltTextService(string apiKey, string model)
+        : this(model, CreateClient(apiKey))
+    {
+    }
+
+    internal OpenAIAltTextService(string model, IOpenAIResponseGenerationClient client)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            throw new ArgumentException("OpenAI model is required.", nameof(model));
+        }
+
+        _model = model;
+        _client = client;
+    }
+
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        if (string.IsNullOrWhiteSpace(model))
-        {
-            throw new ArgumentException("OpenAI model is required.", nameof(model));
-        }
-
-        _chatClient = new ChatClient(model: model, apiKey: apiKey);
+        return new OpenAIResponseGenerationClient(apiKey);
     }
 
     /// <summary>
@@ -35,18 +48,20 @@ public sealed class OpenAIAltTextService : IAltTextService
         cancellationToken.ThrowIfCancellationRequested();
 
         var prompt = BuildImagePrompt(request.ContextBefore, request.ContextAfter);
-        var imageData = BinaryData.FromBytes(request.ImageBytes);
+        var options = OpenAIResponseOptions.Create(
+            _model,
+            "pdf_image_alt_text",
+            OpenAIResponseOptions.AltTextMaxOutputTokens);
 
-        List<ChatMessage> messages =
-        [
-            new SystemChatMessage(BuildSystemInstructions(request.PrimaryLanguage)),
-            new UserChatMessage(
-                ChatMessageContentPart.CreateTextPart(prompt),
-                ChatMessageContentPart.CreateImagePart(imageData, request.MimeType)),
-        ];
+        options.Instructions = BuildSystemInstructions(request.PrimaryLanguage);
+        options.InputItems.Add(
+            ResponseItem.CreateUserMessageItem(
+                [
+                    ResponseContentPart.CreateInputTextPart(prompt),
+                    OpenAIResponseOptions.CreateInputImagePart(request.ImageBytes, request.MimeType),
+                ]));
 
-        ClientResult<ChatCompletion> result = await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
-        var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
+        var text = await _client.CreateResponseAsync(options, cancellationToken);
         return NormalizeAltText(text, fallback: GetFallbackAltTextForImage());
     }
 
@@ -57,14 +72,17 @@ public sealed class OpenAIAltTextService : IAltTextService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        List<ChatMessage> messages =
-        [
-            new SystemChatMessage(BuildSystemInstructions(request.PrimaryLanguage)),
-            new UserChatMessage(BuildLinkPrompt(request.Target, request.LinkText, request.ContextBefore, request.ContextAfter)),
-        ];
+        var options = OpenAIResponseOptions.Create(
+            _model,
+            "pdf_link_alt_text",
+            OpenAIResponseOptions.LinkAltTextMaxOutputTokens);
 
-        ClientResult<ChatCompletion> result = await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
-        var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
+        options.Instructions = BuildSystemInstructions(request.PrimaryLanguage);
+        options.InputItems.Add(
+            ResponseItem.CreateUserMessageItem(
+                BuildLinkPrompt(request.Target, request.LinkText, request.ContextBefore, request.ContextAfter)));
+
+        var text = await _client.CreateResponseAsync(options, cancellationToken);
         return NormalizeAltText(text, fallback: GetFallbackAltTextForLink());
     }
 

--- a/server.core/Remediate/OpenAIPdfCharacterEncodingRepairService.cs
+++ b/server.core/Remediate/OpenAIPdfCharacterEncodingRepairService.cs
@@ -1,7 +1,8 @@
-using System.ClientModel;
+#pragma warning disable OPENAI001
+
 using System.Text;
 using System.Text.Json;
-using OpenAI.Chat;
+using OpenAI.Responses;
 
 namespace server.core.Remediate;
 
@@ -62,21 +63,33 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
         }
         """u8.ToArray());
 
-    private readonly ChatClient _chatClient;
+    private readonly IOpenAIResponseGenerationClient _client;
+    private readonly string _model;
 
     public OpenAIPdfCharacterEncodingRepairService(string apiKey, string model)
+        : this(model, CreateClient(apiKey))
+    {
+    }
+
+    internal OpenAIPdfCharacterEncodingRepairService(string model, IOpenAIResponseGenerationClient client)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            throw new ArgumentException("OpenAI model is required.", nameof(model));
+        }
+
+        _model = model;
+        _client = client;
+    }
+
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        if (string.IsNullOrWhiteSpace(model))
-        {
-            throw new ArgumentException("OpenAI model is required.", nameof(model));
-        }
-
-        _chatClient = new ChatClient(model: model, apiKey: apiKey);
+        return new OpenAIResponseGenerationClient(apiKey);
     }
 
     public async Task<PdfCharacterEncodingRepairResponse> ProposeRepairsAsync(
@@ -90,24 +103,16 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
             return new PdfCharacterEncodingRepairResponse(Array.Empty<PdfCharacterEncodingRepairProposal>());
         }
 
-        List<ChatMessage> messages =
-        [
-            new SystemChatMessage(BuildSystemInstructions()),
-            new UserChatMessage(BuildPrompt(request)),
-        ];
+        var options = OpenAIResponseOptions.Create(
+            _model,
+            "pdf_character_encoding_repairs",
+            OpenAIResponseOptions.CharacterEncodingRepairMaxOutputTokens,
+            OpenAIResponseOptions.CreateJsonSchemaFormat("pdf_character_encoding_repairs", RepairSchema));
 
-        ChatCompletionOptions options = new()
-        {
-            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-                jsonSchemaFormatName: "pdf_character_encoding_repairs",
-                jsonSchema: RepairSchema,
-                jsonSchemaIsStrict: true),
-        };
+        options.Instructions = BuildSystemInstructions();
+        options.InputItems.Add(ResponseItem.CreateUserMessageItem(BuildPrompt(request)));
 
-        ClientResult<ChatCompletion> result =
-            await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
-
-        return ParseResponse(RemediationHelpers.ExtractFirstTextOrEmpty(result.Value));
+        return ParseResponse(await _client.CreateResponseAsync(options, cancellationToken));
     }
 
     public async Task<PdfCharacterEncodingActualTextRepairResponse> ProposeActualTextRepairsAsync(
@@ -121,24 +126,16 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
             return new PdfCharacterEncodingActualTextRepairResponse(Array.Empty<PdfCharacterEncodingActualTextRepairProposal>());
         }
 
-        List<ChatMessage> messages =
-        [
-            new SystemChatMessage(BuildActualTextSystemInstructions()),
-            new UserChatMessage(BuildActualTextPrompt(request)),
-        ];
+        var options = OpenAIResponseOptions.Create(
+            _model,
+            "pdf_character_encoding_actual_text_repairs",
+            OpenAIResponseOptions.CharacterEncodingRepairMaxOutputTokens,
+            OpenAIResponseOptions.CreateJsonSchemaFormat("pdf_character_encoding_actual_text_repairs", ActualTextRepairSchema));
 
-        ChatCompletionOptions options = new()
-        {
-            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-                jsonSchemaFormatName: "pdf_character_encoding_actual_text_repairs",
-                jsonSchema: ActualTextRepairSchema,
-                jsonSchemaIsStrict: true),
-        };
+        options.Instructions = BuildActualTextSystemInstructions();
+        options.InputItems.Add(ResponseItem.CreateUserMessageItem(BuildActualTextPrompt(request)));
 
-        ClientResult<ChatCompletion> result =
-            await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
-
-        return ParseActualTextResponse(RemediationHelpers.ExtractFirstTextOrEmpty(result.Value));
+        return ParseActualTextResponse(await _client.CreateResponseAsync(options, cancellationToken));
     }
 
     private static string BuildSystemInstructions() =>

--- a/server.core/Remediate/OpenAIResponseGenerationClient.cs
+++ b/server.core/Remediate/OpenAIResponseGenerationClient.cs
@@ -1,0 +1,79 @@
+#pragma warning disable OPENAI001
+
+using System.ClientModel;
+using OpenAI.Responses;
+
+namespace server.core.Remediate;
+
+internal interface IOpenAIResponseGenerationClient
+{
+    Task<string> CreateResponseAsync(CreateResponseOptions options, CancellationToken cancellationToken);
+}
+
+internal sealed class OpenAIResponseGenerationClient : IOpenAIResponseGenerationClient
+{
+    private readonly ResponsesClient _client;
+
+    public OpenAIResponseGenerationClient(string apiKey)
+    {
+        _client = new ResponsesClient(apiKey);
+    }
+
+    public async Task<string> CreateResponseAsync(CreateResponseOptions options, CancellationToken cancellationToken)
+    {
+        ClientResult<ResponseResult> result = await _client.CreateResponseAsync(options, cancellationToken);
+        return result.Value.GetOutputText();
+    }
+}
+
+internal static class OpenAIResponseOptions
+{
+    public const int TitleMaxOutputTokens = 256;
+    public const int AltTextMaxOutputTokens = 256;
+    public const int LinkAltTextMaxOutputTokens = 256;
+    public const int TableClassificationMaxOutputTokens = 1024;
+    public const int CharacterEncodingRepairMaxOutputTokens = 8192;
+
+    public static CreateResponseOptions Create(
+        string model,
+        string remediationTask,
+        int maxOutputTokenCount,
+        ResponseTextFormat? textFormat = null)
+    {
+        var options = new CreateResponseOptions
+        {
+            Model = model,
+            StoredOutputEnabled = false,
+            MaxOutputTokenCount = maxOutputTokenCount,
+            ReasoningOptions = new ResponseReasoningOptions
+            {
+                ReasoningEffortLevel = ResponseReasoningEffortLevel.Low,
+            },
+        };
+
+        options.Metadata.Add("feature", "pdf_remediation");
+        options.Metadata.Add("task", remediationTask);
+
+        if (textFormat is not null)
+        {
+            options.TextOptions = new ResponseTextOptions
+            {
+                TextFormat = textFormat,
+            };
+        }
+
+        return options;
+    }
+
+    public static ResponseTextFormat CreateJsonSchemaFormat(string name, BinaryData schema)
+        => ResponseTextFormat.CreateJsonSchemaFormat(
+            jsonSchemaFormatName: name,
+            jsonSchema: schema,
+            jsonSchemaIsStrict: true);
+
+    public static ResponseContentPart CreateInputImagePart(byte[] imageBytes, string mimeType)
+    {
+        var dataUri = $"data:{mimeType};base64,{Convert.ToBase64String(imageBytes)}";
+        return ResponseContentPart.CreateInputImagePart(new Uri(dataUri), imageDetailLevel: null);
+    }
+}

--- a/server.core/Remediate/RemediationHelpers.cs
+++ b/server.core/Remediate/RemediationHelpers.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using OpenAI.Chat;
 
 namespace server.core.Remediate;
 
@@ -34,15 +33,4 @@ internal static class RemediationHelpers
 
         return sb.ToString().Trim();
     }
-
-    public static string ExtractFirstTextOrEmpty(ChatCompletion completion)
-    {
-        if (completion.Content.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        return completion.Content[0].Text ?? string.Empty;
-    }
 }
-

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -1,7 +1,8 @@
-using System.ClientModel;
+#pragma warning disable OPENAI001
+
 using System.Text;
 using System.Text.Json;
-using OpenAI.Chat;
+using OpenAI.Responses;
 
 namespace server.core.Remediate.Table;
 
@@ -31,21 +32,33 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         }
         """u8.ToArray());
 
-    private readonly ChatClient _chatClient;
+    private readonly IOpenAIResponseGenerationClient _client;
+    private readonly string _model;
 
     public OpenAIPdfTableClassificationService(string apiKey, string model)
+        : this(model, CreateClient(apiKey))
+    {
+    }
+
+    internal OpenAIPdfTableClassificationService(string model, IOpenAIResponseGenerationClient client)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            throw new ArgumentException("OpenAI model is required.", nameof(model));
+        }
+
+        _model = model;
+        _client = client;
+    }
+
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        if (string.IsNullOrWhiteSpace(model))
-        {
-            throw new ArgumentException("OpenAI model is required.", nameof(model));
-        }
-
-        _chatClient = new ChatClient(model: model, apiKey: apiKey);
+        return new OpenAIResponseGenerationClient(apiKey);
     }
 
     public async Task<PdfTableClassificationResult> ClassifyAsync(
@@ -54,24 +67,16 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        List<ChatMessage> messages =
-        [
-            new SystemChatMessage(BuildSystemInstructions()),
-            new UserChatMessage(BuildPrompt(request)),
-        ];
+        var options = OpenAIResponseOptions.Create(
+            _model,
+            "pdf_table_classification",
+            OpenAIResponseOptions.TableClassificationMaxOutputTokens,
+            OpenAIResponseOptions.CreateJsonSchemaFormat("pdf_table_classification", ClassificationSchema));
 
-        ChatCompletionOptions options = new()
-        {
-            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-                jsonSchemaFormatName: "pdf_table_classification",
-                jsonSchema: ClassificationSchema,
-                jsonSchemaIsStrict: true),
-        };
+        options.Instructions = BuildSystemInstructions();
+        options.InputItems.Add(ResponseItem.CreateUserMessageItem(BuildPrompt(request)));
 
-        ClientResult<ChatCompletion> result =
-            await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
-
-        var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
+        var text = await _client.CreateResponseAsync(options, cancellationToken);
         return ParseResult(text);
     }
 

--- a/server.core/Remediate/Title/OpenAIPdfTitleService.cs
+++ b/server.core/Remediate/Title/OpenAIPdfTitleService.cs
@@ -1,26 +1,40 @@
-using System.ClientModel;
+#pragma warning disable OPENAI001
+
 using System.Text;
-using OpenAI.Chat;
+using OpenAI.Responses;
+using server.core.Remediate;
 
 namespace server.core.Remediate.Title;
 
 public sealed class OpenAIPdfTitleService : IPdfTitleService
 {
-    private readonly ChatClient _chatClient;
+    private readonly IOpenAIResponseGenerationClient _client;
+    private readonly string _model;
 
     public OpenAIPdfTitleService(string apiKey, string model)
+        : this(model, CreateClient(apiKey))
+    {
+    }
+
+    internal OpenAIPdfTitleService(string model, IOpenAIResponseGenerationClient client)
+    {
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            throw new ArgumentException("OpenAI model is required.", nameof(model));
+        }
+
+        _model = model;
+        _client = client;
+    }
+
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        if (string.IsNullOrWhiteSpace(model))
-        {
-            throw new ArgumentException("OpenAI model is required.", nameof(model));
-        }
-
-        _chatClient = new ChatClient(model: model, apiKey: apiKey);
+        return new OpenAIResponseGenerationClient(apiKey);
     }
 
     /// <summary>
@@ -36,15 +50,14 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
 
         var prompt = BuildPrompt(request.CurrentTitle, request.ExtractedText, request.PrimaryLanguage);
 
-        List<ChatMessage> messages =
-        [
-            new UserChatMessage(prompt),
-        ];
+        var options = OpenAIResponseOptions.Create(
+            _model,
+            "pdf_title",
+            OpenAIResponseOptions.TitleMaxOutputTokens);
 
-        ClientResult<ChatCompletion> result =
-            await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
+        options.InputItems.Add(ResponseItem.CreateUserMessageItem(prompt));
 
-        return RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
+        return await _client.CreateResponseAsync(options, cancellationToken);
     }
 
     /// <summary>

--- a/server.core/server.core.csproj
+++ b/server.core/server.core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Docnet.Core" Version="2.6.0" />
     <PackageReference Include="itext" Version="9.4.0" />
     <PackageReference Include="itext.bouncy-castle-adapter" Version="9.4.0" />
-    <PackageReference Include="OpenAI" Version="2.7.0" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
     <PackageReference Include="Panlingo.LanguageIdentification.Whatlang" Version="0.7.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.21" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />

--- a/tests/server.tests/Remediate/OpenAIRemediationResponseOptionsTests.cs
+++ b/tests/server.tests/Remediate/OpenAIRemediationResponseOptionsTests.cs
@@ -1,0 +1,197 @@
+#pragma warning disable OPENAI001
+
+using System.ClientModel;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using OpenAI.Responses;
+using server.core.Remediate;
+using server.core.Remediate.AltText;
+using server.core.Remediate.Table;
+using server.core.Remediate.Title;
+
+namespace server.tests.Remediate;
+
+public sealed class OpenAIRemediationResponseOptionsTests
+{
+    [Fact]
+    public async Task PdfTitleService_UsesResponsesOptions()
+    {
+        var client = new CapturingResponseGenerationClient("Generated title");
+        var service = new OpenAIPdfTitleService("test-model", client);
+
+        var title = await service.GenerateTitleAsync(
+            new PdfTitleRequest("Current", "Extracted document text.", "English"),
+            CancellationToken.None);
+
+        title.Should().Be("Generated title");
+        var options = client.SingleRequest();
+        AssertCommonOptions(options, "pdf_title", OpenAIResponseOptions.TitleMaxOutputTokens);
+
+        using var json = Serialize(options);
+        json.RootElement.GetProperty("input").GetArrayLength().Should().Be(1);
+        json.RootElement.GetRawText().Should().Contain("Extracted document text.");
+    }
+
+    [Fact]
+    public async Task AltTextService_UsesResponsesOptionsForImageInput()
+    {
+        var client = new CapturingResponseGenerationClient("\"Accessible chart summary\"");
+        var service = new OpenAIAltTextService("test-model", client);
+
+        var altText = await service.GetAltTextForImageAsync(
+            new ImageAltTextRequest([1, 2, 3], "image/png", "Before", "After", "English"),
+            CancellationToken.None);
+
+        altText.Should().Be("Accessible chart summary");
+        var options = client.SingleRequest();
+        AssertCommonOptions(options, "pdf_image_alt_text", OpenAIResponseOptions.AltTextMaxOutputTokens);
+        options.Instructions.Should().Contain("WCAG 2.1-compliant");
+
+        using var json = Serialize(options);
+        var requestJson = json.RootElement.GetRawText();
+        requestJson.Should().Contain("\"type\":\"input_image\"");
+        requestJson.Should().Contain("data:image/png;base64,AQID");
+    }
+
+    [Fact]
+    public async Task TableClassificationService_UsesJsonSchemaResponsesOptions()
+    {
+        var client = new CapturingResponseGenerationClient(
+            """
+            {"kind":"data_table","confidence":0.9,"reason":"Rows contain comparable records."}
+            """);
+        var service = new OpenAIPdfTableClassificationService("test-model", client);
+
+        var result = await service.ClassifyAsync(
+            new PdfTableClassificationRequest(
+                RowCount: 1,
+                MaxColumnCount: 2,
+                HasNestedTable: false,
+                Rows: [["Header", "Value"]],
+                PrimaryLanguage: "English"),
+            CancellationToken.None);
+
+        result.Kind.Should().Be(PdfTableKind.DataTable);
+        var options = client.SingleRequest();
+        AssertCommonOptions(
+            options,
+            "pdf_table_classification",
+            OpenAIResponseOptions.TableClassificationMaxOutputTokens);
+        AssertJsonSchemaOptions(options, "pdf_table_classification");
+    }
+
+    [Fact]
+    public async Task CharacterEncodingRepairService_UsesJsonSchemaResponsesOptions()
+    {
+        var client = new CapturingResponseGenerationClient(
+            """
+            {"repairs":[{"fontObjectId":"12 0 R","sourceCode":"00E9","replacement":"e","confidence":0.8,"reason":"Context supports e."}]}
+            """);
+        var service = new OpenAIPdfCharacterEncodingRepairService("test-model", client);
+
+        var result = await service.ProposeRepairsAsync(
+            new PdfCharacterEncodingRepairRequest(
+                [
+                    new PdfCharacterEncodingAnomalyGroup(
+                        "12 0 R",
+                        "ABCDEF+Font",
+                        "00e9",
+                        "private_use",
+                        [new PdfCharacterEncodingAnomalyContext(1, 2, "caf?", "The word", "appears here")]),
+                ],
+                "English"),
+            CancellationToken.None);
+
+        result.Repairs.Should().ContainSingle();
+        var options = client.SingleRequest();
+        AssertCommonOptions(
+            options,
+            "pdf_character_encoding_repairs",
+            OpenAIResponseOptions.CharacterEncodingRepairMaxOutputTokens);
+        AssertJsonSchemaOptions(options, "pdf_character_encoding_repairs");
+    }
+
+    [Fact]
+    public async Task CharacterEncodingActualTextRepairService_UsesJsonSchemaResponsesOptions()
+    {
+        var client = new CapturingResponseGenerationClient(
+            """
+            {"repairs":[{"pageNumber":1,"mcid":2,"actualText":"Cafe","confidence":0.8,"reason":"Context supports Cafe."}]}
+            """);
+        var service = new OpenAIPdfCharacterEncodingRepairService("test-model", client);
+
+        var result = await service.ProposeActualTextRepairsAsync(
+            new PdfCharacterEncodingActualTextRepairRequest(
+                [new PdfCharacterEncodingActualTextIssue(1, 2, "Caf?", "The word", "appears here")],
+                "English"),
+            CancellationToken.None);
+
+        result.Repairs.Should().ContainSingle();
+        var options = client.SingleRequest();
+        AssertCommonOptions(
+            options,
+            "pdf_character_encoding_actual_text_repairs",
+            OpenAIResponseOptions.CharacterEncodingRepairMaxOutputTokens);
+        AssertJsonSchemaOptions(options, "pdf_character_encoding_actual_text_repairs");
+    }
+
+    private static void AssertCommonOptions(
+        CreateResponseOptions options,
+        string expectedTask,
+        int expectedMaxOutputTokenCount)
+    {
+        options.Model.Should().Be("test-model");
+        options.StoredOutputEnabled.Should().BeFalse();
+        options.MaxOutputTokenCount.Should().Be(expectedMaxOutputTokenCount);
+        options.ReasoningOptions.Should().NotBeNull();
+        options.ReasoningOptions!.ReasoningEffortLevel.Should().Be(ResponseReasoningEffortLevel.Low);
+        options.Metadata.Should().Contain("feature", "pdf_remediation");
+        options.Metadata.Should().Contain("task", expectedTask);
+    }
+
+    private static void AssertJsonSchemaOptions(CreateResponseOptions options, string expectedSchemaName)
+    {
+        options.TextOptions.Should().NotBeNull();
+        options.TextOptions!.TextFormat.Should().NotBeNull();
+        options.TextOptions.TextFormat.Kind.Should().Be(ResponseTextFormatKind.JsonSchema);
+
+        using var json = Serialize(options);
+        var requestJson = json.RootElement.GetRawText();
+        requestJson.Should().Contain("\"type\":\"json_schema\"");
+        requestJson.Should().Contain($"\"name\":\"{expectedSchemaName}\"");
+        requestJson.Should().Contain("\"strict\":true");
+    }
+
+    private static JsonDocument Serialize(CreateResponseOptions options)
+    {
+        BinaryContent content = options;
+        using var stream = new MemoryStream();
+        content.WriteTo(stream, CancellationToken.None);
+        return JsonDocument.Parse(Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    private sealed class CapturingResponseGenerationClient : IOpenAIResponseGenerationClient
+    {
+        private readonly string _response;
+        private readonly List<CreateResponseOptions> _requests = [];
+
+        public CapturingResponseGenerationClient(string response)
+        {
+            _response = response;
+        }
+
+        public Task<string> CreateResponseAsync(CreateResponseOptions options, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _requests.Add(options);
+            return Task.FromResult(_response);
+        }
+
+        public CreateResponseOptions SingleRequest()
+        {
+            _requests.Should().ContainSingle();
+            return _requests[0];
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #96.

- Migrate OpenAI-backed PDF remediation services from Chat Completions to the Responses API.
- Add a shared Responses client/options helper for low reasoning effort, output caps, request metadata, `store: false`, and JSON schema formatting.
- Preserve existing remediation service interfaces and caller behavior.
- Add offline tests that capture Responses request options for title, alt text, table classification, and character encoding repair paths.
- Upgrade the OpenAI .NET SDK package from `2.7.0` to `2.10.0`.

## Notes

The current OpenAI .NET SDK still marks Responses SDK types as `OPENAI001`, so suppressions remain narrowly scoped to the Responses integration and tests.

A real API smoke test against `gpt-5-mini` passed for title generation and table classification. Follow-up latency investigation for minimal reasoning is tracked in #101.

## Verification

- `rg` confirmed no remaining `ChatClient`, `CompleteChatAsync`, or `OpenAI.Chat` usage under `server.core` / server tests.
- `/usr/local/share/dotnet/dotnet build app.sln`
- `/usr/local/share/dotnet/dotnet test app.sln`
- Real API smoke test:
  - Title: `UC Davis Campus PDF Accessibility Remediation Workflows and Validation Guide`
  - Table classification: `DataTable`, confidence `0.94`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenAI SDK dependency to version 2.10.0.

* **Refactor**
  * Refactored PDF remediation services (alt text generation, title generation, table classification, and character encoding repair) to use the latest OpenAI API for improved performance and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/readable/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->