### PR TITLE
Add bounded OpenAI remediation concurrency

### DIFF
--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -134,6 +134,13 @@ public static class IngestServiceCollectionExtensions
                     configuration.GetValue<double?>("Ingest:CharacterEncodingRepairConfidenceThreshold")
                     ?? configuration.GetValue<double?>("INGEST_CHARACTER_ENCODING_REPAIR_CONFIDENCE_THRESHOLD")
                     ?? 0.50;
+
+                o.OpenAiMaxConcurrency = Math.Clamp(
+                    configuration.GetValue<int?>("Ingest:OpenAiMaxConcurrency")
+                    ?? configuration.GetValue<int?>("INGEST_OPENAI_MAX_CONCURRENCY")
+                    ?? 4,
+                    1,
+                    8);
             });
 
             services.AddSingleton<OpenAiRemediationConfig>(sp =>

--- a/server.core/Ingest/IngestServiceCollectionExtensions.cs
+++ b/server.core/Ingest/IngestServiceCollectionExtensions.cs
@@ -179,6 +179,7 @@ public static class IngestServiceCollectionExtensions
 
                 return new OpenAiRemediationConfig(
                     apiKey,
+                    GetOpenAiEndpoint(configuration),
                     altTextModel,
                     pdfTitleModel,
                     pdfTableClassificationModel,
@@ -187,22 +188,22 @@ public static class IngestServiceCollectionExtensions
             services.AddSingleton<IAltTextService>(sp =>
             {
                 var cfg = sp.GetRequiredService<OpenAiRemediationConfig>();
-                return new OpenAIAltTextService(cfg.ApiKey, cfg.AltTextModel);
+                return new OpenAIAltTextService(cfg.ApiKey, cfg.AltTextModel, cfg.Endpoint);
             });
             services.AddSingleton<IPdfTitleService>(sp =>
             {
                 var cfg = sp.GetRequiredService<OpenAiRemediationConfig>();
-                return new OpenAIPdfTitleService(cfg.ApiKey, cfg.PdfTitleModel);
+                return new OpenAIPdfTitleService(cfg.ApiKey, cfg.PdfTitleModel, cfg.Endpoint);
             });
             services.AddSingleton<IPdfTableClassificationService>(sp =>
             {
                 var cfg = sp.GetRequiredService<OpenAiRemediationConfig>();
-                return new OpenAIPdfTableClassificationService(cfg.ApiKey, cfg.PdfTableClassificationModel);
+                return new OpenAIPdfTableClassificationService(cfg.ApiKey, cfg.PdfTableClassificationModel, cfg.Endpoint);
             });
             services.AddSingleton<IPdfCharacterEncodingRepairService>(sp =>
             {
                 var cfg = sp.GetRequiredService<OpenAiRemediationConfig>();
-                return new OpenAIPdfCharacterEncodingRepairService(cfg.ApiKey, cfg.PdfCharacterEncodingModel);
+                return new OpenAIPdfCharacterEncodingRepairService(cfg.ApiKey, cfg.PdfCharacterEncodingModel, cfg.Endpoint);
             });
             if (options.UsePdfBookmarks)
             {
@@ -249,8 +250,20 @@ public static class IngestServiceCollectionExtensions
             ?? configuration["OpenAI__ApiKey"];
     }
 
+    private static string? GetOpenAiEndpoint(IConfiguration configuration)
+    {
+        return
+            configuration["OPENAI_ENDPOINT"]
+            ?? configuration["OPENAI_BASE_URL"]
+            ?? configuration["OpenAI:Endpoint"]
+            ?? configuration["OpenAI:BaseUrl"]
+            ?? configuration["OpenAI__Endpoint"]
+            ?? configuration["OpenAI__BaseUrl"];
+    }
+
     private sealed record OpenAiRemediationConfig(
         string ApiKey,
+        string? Endpoint,
         string AltTextModel,
         string PdfTitleModel,
         string PdfTableClassificationModel,

--- a/server.core/Remediate/AltText/OpenAIAltTextService.cs
+++ b/server.core/Remediate/AltText/OpenAIAltTextService.cs
@@ -7,6 +7,7 @@ namespace server.core.Remediate.AltText;
 public sealed class OpenAIAltTextService : IAltTextService
 {
     private readonly ChatClient _chatClient;
+    private readonly string _model;
 
     public OpenAIAltTextService(string apiKey, string model)
     {
@@ -20,6 +21,7 @@ public sealed class OpenAIAltTextService : IAltTextService
             throw new ArgumentException("OpenAI model is required.", nameof(model));
         }
 
+        _model = model;
         _chatClient = new ChatClient(model: model, apiKey: apiKey);
     }
 
@@ -45,7 +47,10 @@ public sealed class OpenAIAltTextService : IAltTextService
                 ChatMessageContentPart.CreateImagePart(imageData, request.MimeType)),
         ];
 
-        ClientResult<ChatCompletion> result = await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
+        ClientResult<ChatCompletion> result = await _chatClient.CompleteChatAsync(
+            messages,
+            RemediationHelpers.CreateFastChatOptions(_model, maxOutputTokenCount: 300),
+            cancellationToken);
         var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
         return NormalizeAltText(text, fallback: GetFallbackAltTextForImage());
     }
@@ -63,7 +68,10 @@ public sealed class OpenAIAltTextService : IAltTextService
             new UserChatMessage(BuildLinkPrompt(request.Target, request.LinkText, request.ContextBefore, request.ContextAfter)),
         ];
 
-        ClientResult<ChatCompletion> result = await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
+        ClientResult<ChatCompletion> result = await _chatClient.CompleteChatAsync(
+            messages,
+            RemediationHelpers.CreateFastChatOptions(_model, maxOutputTokenCount: 300),
+            cancellationToken);
         var text = RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
         return NormalizeAltText(text, fallback: GetFallbackAltTextForLink());
     }

--- a/server.core/Remediate/AltText/OpenAIAltTextService.cs
+++ b/server.core/Remediate/AltText/OpenAIAltTextService.cs
@@ -11,7 +11,12 @@ public sealed class OpenAIAltTextService : IAltTextService
     private readonly string _model;
 
     public OpenAIAltTextService(string apiKey, string model)
-        : this(model, CreateClient(apiKey))
+        : this(apiKey, model, endpoint: null)
+    {
+    }
+
+    public OpenAIAltTextService(string apiKey, string model, string? endpoint)
+        : this(model, CreateClient(apiKey, endpoint))
     {
     }
 
@@ -26,14 +31,14 @@ public sealed class OpenAIAltTextService : IAltTextService
         _client = client;
     }
 
-    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey, string? endpoint)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        return new OpenAIResponseGenerationClient(apiKey);
+        return new OpenAIResponseGenerationClient(apiKey, endpoint);
     }
 
     /// <summary>

--- a/server.core/Remediate/OpenAIPdfCharacterEncodingRepairService.cs
+++ b/server.core/Remediate/OpenAIPdfCharacterEncodingRepairService.cs
@@ -63,6 +63,7 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
         """u8.ToArray());
 
     private readonly ChatClient _chatClient;
+    private readonly string _model;
 
     public OpenAIPdfCharacterEncodingRepairService(string apiKey, string model)
     {
@@ -76,6 +77,7 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
             throw new ArgumentException("OpenAI model is required.", nameof(model));
         }
 
+        _model = model;
         _chatClient = new ChatClient(model: model, apiKey: apiKey);
     }
 
@@ -96,13 +98,11 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
             new UserChatMessage(BuildPrompt(request)),
         ];
 
-        ChatCompletionOptions options = new()
-        {
-            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-                jsonSchemaFormatName: "pdf_character_encoding_repairs",
-                jsonSchema: RepairSchema,
-                jsonSchemaIsStrict: true),
-        };
+        var options = RemediationHelpers.CreateFastChatOptions(_model, maxOutputTokenCount: 4000);
+        options.ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
+            jsonSchemaFormatName: "pdf_character_encoding_repairs",
+            jsonSchema: RepairSchema,
+            jsonSchemaIsStrict: true);
 
         ClientResult<ChatCompletion> result =
             await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
@@ -127,13 +127,11 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
             new UserChatMessage(BuildActualTextPrompt(request)),
         ];
 
-        ChatCompletionOptions options = new()
-        {
-            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-                jsonSchemaFormatName: "pdf_character_encoding_actual_text_repairs",
-                jsonSchema: ActualTextRepairSchema,
-                jsonSchemaIsStrict: true),
-        };
+        var options = RemediationHelpers.CreateFastChatOptions(_model, maxOutputTokenCount: 4000);
+        options.ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
+            jsonSchemaFormatName: "pdf_character_encoding_actual_text_repairs",
+            jsonSchema: ActualTextRepairSchema,
+            jsonSchemaIsStrict: true);
 
         ClientResult<ChatCompletion> result =
             await _chatClient.CompleteChatAsync(messages, options, cancellationToken);

--- a/server.core/Remediate/OpenAIPdfCharacterEncodingRepairService.cs
+++ b/server.core/Remediate/OpenAIPdfCharacterEncodingRepairService.cs
@@ -67,7 +67,12 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
     private readonly string _model;
 
     public OpenAIPdfCharacterEncodingRepairService(string apiKey, string model)
-        : this(model, CreateClient(apiKey))
+        : this(apiKey, model, endpoint: null)
+    {
+    }
+
+    public OpenAIPdfCharacterEncodingRepairService(string apiKey, string model, string? endpoint)
+        : this(model, CreateClient(apiKey, endpoint))
     {
     }
 
@@ -82,14 +87,14 @@ public sealed class OpenAIPdfCharacterEncodingRepairService : IPdfCharacterEncod
         _client = client;
     }
 
-    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey, string? endpoint)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        return new OpenAIResponseGenerationClient(apiKey);
+        return new OpenAIResponseGenerationClient(apiKey, endpoint);
     }
 
     public async Task<PdfCharacterEncodingRepairResponse> ProposeRepairsAsync(

--- a/server.core/Remediate/OpenAIResponseGenerationClient.cs
+++ b/server.core/Remediate/OpenAIResponseGenerationClient.cs
@@ -13,6 +13,7 @@ internal interface IOpenAIResponseGenerationClient
 
 internal sealed class OpenAIResponseGenerationClient : IOpenAIResponseGenerationClient
 {
+    private const string DefaultEndpoint = "https://us.api.openai.com/v1";
     private readonly ResponsesClient _client;
 
     public OpenAIResponseGenerationClient(string apiKey)
@@ -22,17 +23,14 @@ internal sealed class OpenAIResponseGenerationClient : IOpenAIResponseGeneration
 
     public OpenAIResponseGenerationClient(string apiKey, string? endpoint)
     {
-        if (string.IsNullOrWhiteSpace(endpoint))
-        {
-            _client = new ResponsesClient(apiKey);
-            return;
-        }
-
         _client = new ResponsesClient(
             new ApiKeyCredential(apiKey),
             new OpenAIClientOptions
             {
-                Endpoint = NormalizeEndpoint(endpoint),
+                Endpoint = NormalizeEndpoint(
+                    string.IsNullOrWhiteSpace(endpoint)
+                        ? DefaultEndpoint
+                        : endpoint),
             });
     }
 

--- a/server.core/Remediate/OpenAIResponseGenerationClient.cs
+++ b/server.core/Remediate/OpenAIResponseGenerationClient.cs
@@ -1,6 +1,7 @@
 #pragma warning disable OPENAI001
 
 using System.ClientModel;
+using OpenAI;
 using OpenAI.Responses;
 
 namespace server.core.Remediate;
@@ -15,14 +16,41 @@ internal sealed class OpenAIResponseGenerationClient : IOpenAIResponseGeneration
     private readonly ResponsesClient _client;
 
     public OpenAIResponseGenerationClient(string apiKey)
+        : this(apiKey, endpoint: null)
     {
-        _client = new ResponsesClient(apiKey);
+    }
+
+    public OpenAIResponseGenerationClient(string apiKey, string? endpoint)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            _client = new ResponsesClient(apiKey);
+            return;
+        }
+
+        _client = new ResponsesClient(
+            new ApiKeyCredential(apiKey),
+            new OpenAIClientOptions
+            {
+                Endpoint = NormalizeEndpoint(endpoint),
+            });
     }
 
     public async Task<string> CreateResponseAsync(CreateResponseOptions options, CancellationToken cancellationToken)
     {
         ClientResult<ResponseResult> result = await _client.CreateResponseAsync(options, cancellationToken);
         return result.Value.GetOutputText();
+    }
+
+    private static Uri NormalizeEndpoint(string endpoint)
+    {
+        var uri = new Uri(endpoint);
+        if (string.IsNullOrWhiteSpace(uri.AbsolutePath) || uri.AbsolutePath == "/")
+        {
+            return new Uri(uri, "/v1");
+        }
+
+        return uri;
     }
 }
 

--- a/server.core/Remediate/PdfRemediationOptions.cs
+++ b/server.core/Remediate/PdfRemediationOptions.cs
@@ -22,6 +22,11 @@ public sealed class PdfRemediationOptions
     public double CharacterEncodingRepairConfidenceThreshold { get; set; } = 0.50;
 
     /// <summary>
+    /// Maximum number of independent OpenAI remediation calls to run at the same time inside one PDF job.
+    /// </summary>
+    public int OpenAiMaxConcurrency { get; set; } = 4;
+
+    /// <summary>
     /// When enabled, demotes small <c>/Table</c> tag-tree elements that have no <c>/TH</c> header cells to <c>/Div</c>.
     /// </summary>
     /// <remarks>

--- a/server.core/Remediate/PdfRemediationProcessor.cs
+++ b/server.core/Remediate/PdfRemediationProcessor.cs
@@ -312,6 +312,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                     demoteNoHeaderTables: _options.DemoteNoHeaderTables,
                     promoteFirstRowHeadersForNoHeaderTables: _options.PromoteFirstRowHeadersForNoHeaderTables,
                     classificationTimeout: TimeSpan.FromSeconds(Math.Max(1, _options.NoHeaderTableClassificationTimeoutSeconds)),
+                    openAiMaxConcurrency: _options.OpenAiMaxConcurrency,
                     cancellationToken);
             }
             foreach (var tableRemediation in noHeaderTableRemediations)
@@ -397,7 +398,8 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
             var imageAltFailures = 0;
             var linkOccurrences = 0;
             var linkAltSet = 0;
-            var rasterAltByImageHash = new Dictionary<string, string>(StringComparer.Ordinal);
+            var rasterImageAltWorkByHash = new Dictionary<string, ImageAltTextWorkItem>(StringComparer.Ordinal);
+            var linkAltWorkItems = new List<LinkAltTextWorkItem>();
 
             using (LogStage.Begin(
                        _logger,
@@ -449,46 +451,18 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         }
 
                         var imageHash = Convert.ToHexString(SHA256.HashData(bytes));
-                        if (rasterAltByImageHash.TryGetValue(imageHash, out var cachedAltText))
+                        if (rasterImageAltWorkByHash.TryGetValue(imageHash, out var existingWorkItem))
                         {
                             imageAltDedupeHits++;
-                            SetAlt(figure, cachedAltText);
-                            if (!string.IsNullOrWhiteSpace(cachedAltText))
-                            {
-                                imageAltSet++;
-                            }
-
+                            existingWorkItem.Figures.Add(figure);
                             continue;
                         }
 
-                        string altText;
-                        try
-                        {
-                            altText = await _altTextService.GetAltTextForImageAsync(
-                                new ImageAltTextRequest(bytes, mimeType, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
-                                cancellationToken);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            throw;
-                        }
-                        catch (Exception ex)
-                        {
-                            imageAltFailures++;
-                            _logger.LogWarning(
-                                ex,
-                                "Failed to generate raster image alt text for {fileId} page={pageNumber}. Figure will remain without Alt for manual remediation.",
-                                fileId,
-                                pageNumber);
-                            continue;
-                        }
-
-                        rasterAltByImageHash[imageHash] = altText;
-                        SetAlt(figure, altText);
-                        if (!string.IsNullOrWhiteSpace(altText))
-                        {
-                            imageAltSet++;
-                        }
+                        rasterImageAltWorkByHash[imageHash] = new ImageAltTextWorkItem(
+                            imageHash,
+                            new ImageAltTextRequest(bytes, mimeType, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
+                            pageNumber,
+                            figure);
                     }
 
                     if (!_options.GenerateLinkAltText)
@@ -513,14 +487,56 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                         }
 
                         var target = TryGetLinkTarget(occ.LinkAnnotation);
-                        var altText = await _altTextService.GetAltTextForLinkAsync(
-                            new LinkAltTextRequest(target, occ.LinkText, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
-                            cancellationToken);
-                        SetAlt(link, altText);
-                        if (!string.IsNullOrWhiteSpace(altText))
+                        linkAltWorkItems.Add(
+                            new LinkAltTextWorkItem(
+                                link,
+                                new LinkAltTextRequest(target, occ.LinkText, occ.ContextBefore, occ.ContextAfter, primaryLanguage),
+                                pageNumber));
+                    }
+                }
+
+                var rasterResults = await RunOpenAiTextWorkAsync(
+                    rasterImageAltWorkByHash.Values.ToArray(),
+                    (item, ct) => _altTextService.GetAltTextForImageAsync(item.Request, ct),
+                    cancellationToken);
+                foreach (var result in rasterResults)
+                {
+                    if (result.Exception is not null)
+                    {
+                        imageAltFailures++;
+                        _logger.LogWarning(
+                            result.Exception,
+                            "Failed to generate raster image alt text for {fileId} page={pageNumber}. Figure will remain without Alt for manual remediation.",
+                            fileId,
+                            result.Item.PageNumber);
+                        continue;
+                    }
+
+                    foreach (var figure in result.Item.Figures)
+                    {
+                        SetAlt(figure, result.Text ?? string.Empty);
+                        if (!string.IsNullOrWhiteSpace(result.Text))
                         {
-                            linkAltSet++;
+                            imageAltSet++;
                         }
+                    }
+                }
+
+                var linkResults = await RunOpenAiTextWorkAsync(
+                    linkAltWorkItems,
+                    (item, ct) => _altTextService.GetAltTextForLinkAsync(item.Request, ct),
+                    cancellationToken);
+                foreach (var result in linkResults)
+                {
+                    if (result.Exception is not null)
+                    {
+                        throw result.Exception;
+                    }
+
+                    SetAlt(result.Item.Link, result.Text ?? string.Empty);
+                    if (!string.IsNullOrWhiteSpace(result.Text))
+                    {
+                        linkAltSet++;
                     }
                 }
             }
@@ -573,7 +589,7 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
                     if (targetMcidsByPage.Count > 0)
                     {
-                        Dictionary<string, string> altByImageHash = new(StringComparer.Ordinal);
+                        Dictionary<string, ImageAltTextWorkItem> vectorImageAltWorkByHash = new(StringComparer.Ordinal);
 
                         IPdfRasterDocument? rasterDoc = null;
                         try
@@ -766,57 +782,54 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
                                         }
 
                                         var hash = Convert.ToHexString(SHA256.HashData(pngBytes));
-                                        if (altByImageHash.TryGetValue(hash, out var dedupedAlt))
+                                        if (vectorImageAltWorkByHash.TryGetValue(hash, out var existingWorkItem))
                                         {
                                             vectorAltDedupeHits++;
-                                            SetAlt(candidate.Figure, dedupedAlt);
-                                            if (IsMeaningfulImageAltText(dedupedAlt))
-                                            {
-                                                vectorNonPlaceholderAltSet++;
-                                            }
-                                            else if (IsPlaceholderImageAltText(dedupedAlt))
-                                            {
-                                                vectorAltPlaceholderResponses++;
-                                            }
-
+                                            existingWorkItem.Figures.Add(candidate.Figure);
                                             continue;
                                         }
 
-                                        string altText;
-                                        try
-                                        {
-                                            altText = await _altTextService.GetAltTextForImageAsync(
+                                        vectorImageAltWorkByHash[hash] = new ImageAltTextWorkItem(
+                                            hash,
                                                 new ImageAltTextRequest(
                                                     pngBytes,
                                                     "image/png",
                                                     candidate.ContextBefore,
                                                     candidate.ContextAfter,
                                                     primaryLanguage),
-                                                cancellationToken);
-                                        }
-                                        catch (OperationCanceledException)
-                                        {
-                                            throw;
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            vectorAltFailures++;
-                                            _logger.LogWarning(ex, "Failed to generate vector figure alt text on page {pageNumber}.", pageNumber);
-                                            continue;
-                                        }
+                                            pageNumber,
+                                            candidate.Figure);
+                                    }
+                                }
+                            }
 
-                                        altByImageHash[hash] = altText;
-                                        vectorUniqueImages++;
+                            var vectorResults = await RunOpenAiTextWorkAsync(
+                                vectorImageAltWorkByHash.Values.ToArray(),
+                                (item, ct) => _altTextService.GetAltTextForImageAsync(item.Request, ct),
+                                cancellationToken);
+                            foreach (var result in vectorResults)
+                            {
+                                if (result.Exception is not null)
+                                {
+                                    vectorAltFailures++;
+                                    _logger.LogWarning(
+                                        result.Exception,
+                                        "Failed to generate vector figure alt text on page {pageNumber}.",
+                                        result.Item.PageNumber);
+                                    continue;
+                                }
 
-                                        SetAlt(candidate.Figure, altText);
-                                        if (IsMeaningfulImageAltText(altText))
-                                        {
-                                            vectorNonPlaceholderAltSet++;
-                                        }
-                                        else if (IsPlaceholderImageAltText(altText))
-                                        {
-                                            vectorAltPlaceholderResponses++;
-                                        }
+                                vectorUniqueImages++;
+                                foreach (var figure in result.Item.Figures)
+                                {
+                                    SetAlt(figure, result.Text ?? string.Empty);
+                                    if (IsMeaningfulImageAltText(result.Text ?? string.Empty))
+                                    {
+                                        vectorNonPlaceholderAltSet++;
+                                    }
+                                    else if (IsPlaceholderImageAltText(result.Text ?? string.Empty))
+                                    {
+                                        vectorAltPlaceholderResponses++;
                                     }
                                 }
                             }
@@ -1537,6 +1550,73 @@ public sealed class PdfRemediationProcessor : IPdfRemediationProcessor
 
         structElem.Put(PdfName.Alt, new PdfString(altText, PdfEncodings.UNICODE_BIG));
     }
+
+    private async Task<IReadOnlyList<OpenAiTextWorkResult<TItem>>> RunOpenAiTextWorkAsync<TItem>(
+        IReadOnlyList<TItem> items,
+        Func<TItem, CancellationToken, Task<string>> generateAsync,
+        CancellationToken cancellationToken)
+    {
+        if (items.Count == 0)
+        {
+            return [];
+        }
+
+        var maxConcurrency = Math.Clamp(_options.OpenAiMaxConcurrency, 1, 8);
+        using var semaphore = new SemaphoreSlim(maxConcurrency);
+        var tasks = items.Select(async item =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var text = await generateAsync(item, cancellationToken);
+                return new OpenAiTextWorkResult<TItem>(item, text, null);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                return new OpenAiTextWorkResult<TItem>(item, null, ex);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        return await Task.WhenAll(tasks);
+    }
+
+    private sealed class ImageAltTextWorkItem
+    {
+        public ImageAltTextWorkItem(
+            string hash,
+            ImageAltTextRequest request,
+            int pageNumber,
+            PdfDictionary figure)
+        {
+            Hash = hash;
+            Request = request;
+            PageNumber = pageNumber;
+            Figures = [figure];
+        }
+
+        public string Hash { get; }
+        public ImageAltTextRequest Request { get; }
+        public int PageNumber { get; }
+        public List<PdfDictionary> Figures { get; }
+    }
+
+    private sealed record LinkAltTextWorkItem(
+        PdfDictionary Link,
+        LinkAltTextRequest Request,
+        int PageNumber);
+
+    private sealed record OpenAiTextWorkResult<TItem>(
+        TItem Item,
+        string? Text,
+        Exception? Exception);
 
     private sealed class VectorFigureCandidate
     {

--- a/server.core/Remediate/PdfTableRoleRemediator.cs
+++ b/server.core/Remediate/PdfTableRoleRemediator.cs
@@ -81,6 +81,7 @@ internal static class PdfTableRoleRemediator
         bool demoteNoHeaderTables,
         bool promoteFirstRowHeadersForNoHeaderTables,
         TimeSpan classificationTimeout,
+        int openAiMaxConcurrency,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -103,7 +104,8 @@ internal static class PdfTableRoleRemediator
 
         var pageObjNumToPageNumber = BuildPageObjectNumberToPageNumberMap(pdf);
         var pageMcidTextCache = new Dictionary<int, Dictionary<int, string>>();
-        var results = new List<PdfNoHeaderTableRemediation>();
+        var results = new List<PdfNoHeaderTableRemediation?>();
+        var classificationCandidates = new List<TableClassificationCandidate>();
 
         foreach (var table in tables)
         {
@@ -134,31 +136,39 @@ internal static class PdfTableRoleRemediator
             }
 
             var request = inventory.ToClassificationRequest(primaryLanguage);
-            PdfTableClassificationResult classification;
-            try
+            var resultIndex = results.Count;
+            results.Add(null);
+            classificationCandidates.Add(new TableClassificationCandidate(resultIndex, inventory, request));
+        }
+
+        var classificationOutcomes = await ClassifyNoHeaderTablesAsync(
+            tableClassificationService,
+            classificationCandidates,
+            classificationTimeout,
+            openAiMaxConcurrency,
+            cancellationToken);
+
+        foreach (var outcome in classificationOutcomes.OrderBy(o => o.Candidate.ResultIndex))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var inventory = outcome.Candidate.Inventory;
+            if (outcome.Exception is OperationCanceledException)
             {
-                classification = await ClassifyWithTimeoutAsync(
-                    tableClassificationService,
-                    request,
-                    classificationTimeout,
-                    cancellationToken);
-            }
-            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-            {
-                results.Add(CreateUnchangedResult(inventory, "left unchanged; table classification timed out"));
+                results[outcome.Candidate.ResultIndex] =
+                    CreateUnchangedResult(inventory, "left unchanged; table classification timed out");
                 continue;
             }
-            catch (OperationCanceledException)
+
+            if (outcome.Exception is not null)
             {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                results.Add(CreateUnchangedResult(
+                results[outcome.Candidate.ResultIndex] = CreateUnchangedResult(
                     inventory,
-                    $"left unchanged; table classification failed: {ex.GetType().Name}"));
+                    $"left unchanged; table classification failed: {outcome.Exception.GetType().Name}");
                 continue;
             }
+
+            var classification = outcome.Classification!;
 
             var confidence = Math.Clamp(classification.Confidence, 0, 1);
             var isConfidentDataTable = classification.Kind == PdfTableKind.DataTable
@@ -168,16 +178,16 @@ internal static class PdfTableRoleRemediator
             {
                 if (!promoteFirstRowHeadersForNoHeaderTables)
                 {
-                    results.Add(CreateUnchangedResult(
+                    results[outcome.Candidate.ResultIndex] = CreateUnchangedResult(
                         inventory,
                         BuildClassifierDecisionReason(
                             "classified as data table; first-row header promotion disabled",
-                            classification)));
+                            classification));
                     continue;
                 }
 
                 var promoted = PromoteHeaderRowToTableHead(inventory, cancellationToken);
-                results.Add(
+                results[outcome.Candidate.ResultIndex] =
                     new PdfNoHeaderTableRemediation(
                         promoted
                             ? PdfNoHeaderTableRemediationAction.PromotedHeaderRow
@@ -189,24 +199,24 @@ internal static class PdfTableRoleRemediator
                             promoted
                                 ? "classified as data table; moved header row into THead and promoted cells to TH"
                                 : "classified as data table but no usable header row was available to promote",
-                            classification)));
+                            classification));
                 continue;
             }
 
             if (!demoteNoHeaderTables)
             {
-                results.Add(CreateUnchangedResult(
+                results[outcome.Candidate.ResultIndex] = CreateUnchangedResult(
                     inventory,
                     BuildClassifierDecisionReason(
                         classification.Kind == PdfTableKind.DataTable
                             ? $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; no-header table demotion disabled"
                             : "classified as non-data table; no-header table demotion disabled",
-                        classification)));
+                        classification));
                 continue;
             }
 
-            DemoteTableAndDescendants(table, cancellationToken);
-            results.Add(
+            DemoteTableAndDescendants(inventory.Element, cancellationToken);
+            results[outcome.Candidate.ResultIndex] =
                 new PdfNoHeaderTableRemediation(
                     PdfNoHeaderTableRemediationAction.DemotedNoHeaderTable,
                     inventory.RowCount,
@@ -216,10 +226,54 @@ internal static class PdfTableRoleRemediator
                         classification.Kind == PdfTableKind.DataTable
                             ? $"data-table classifier confidence {confidence:0.00} was below {MinClassifierConfidence:0.00}; demoted table roles"
                             : "classified as non-data table; demoted table roles",
-                        classification)));
+                        classification));
         }
 
-        return results;
+        return results.Where(r => r is not null).Select(r => r!).ToArray();
+    }
+
+    private static async Task<IReadOnlyList<TableClassificationOutcome>> ClassifyNoHeaderTablesAsync(
+        IPdfTableClassificationService tableClassificationService,
+        IReadOnlyList<TableClassificationCandidate> candidates,
+        TimeSpan classificationTimeout,
+        int openAiMaxConcurrency,
+        CancellationToken cancellationToken)
+    {
+        if (candidates.Count == 0)
+        {
+            return [];
+        }
+
+        var maxConcurrency = Math.Clamp(openAiMaxConcurrency, 1, 8);
+        using var semaphore = new SemaphoreSlim(maxConcurrency);
+        var tasks = candidates.Select(async candidate =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var classification = await ClassifyWithTimeoutAsync(
+                    tableClassificationService,
+                    candidate.Request,
+                    classificationTimeout,
+                    cancellationToken);
+
+                return new TableClassificationOutcome(candidate, classification, null);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                return new TableClassificationOutcome(candidate, null, ex);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        return await Task.WhenAll(tasks);
     }
 
     private static string BuildClassifierDecisionReason(
@@ -260,6 +314,16 @@ internal static class PdfTableRoleRemediator
             throw new OperationCanceledException("Table classification timed out.", ex, timeoutCts.Token);
         }
     }
+
+    private sealed record TableClassificationCandidate(
+        int ResultIndex,
+        TableInventory Inventory,
+        PdfTableClassificationRequest Request);
+
+    private sealed record TableClassificationOutcome(
+        TableClassificationCandidate Candidate,
+        PdfTableClassificationResult? Classification,
+        Exception? Exception);
 
     private static PdfNoHeaderTableRemediation CreateUnchangedResult(TableInventory inventory, string reason) =>
         new(

--- a/server.core/Remediate/RemediationHelpers.cs
+++ b/server.core/Remediate/RemediationHelpers.cs
@@ -44,5 +44,30 @@ internal static class RemediationHelpers
 
         return completion.Content[0].Text ?? string.Empty;
     }
-}
 
+    public static ChatCompletionOptions CreateFastChatOptions(string model, int maxOutputTokenCount)
+    {
+        var options = new ChatCompletionOptions
+        {
+            MaxOutputTokenCount = maxOutputTokenCount,
+        };
+
+        if (SupportsReasoningEffort(model))
+        {
+#pragma warning disable OPENAI001
+            options.ReasoningEffortLevel = ChatReasoningEffortLevel.Low;
+#pragma warning restore OPENAI001
+        }
+
+        return options;
+    }
+
+    private static bool SupportsReasoningEffort(string model)
+    {
+        model = NormalizeWhitespace(model).ToLowerInvariant();
+        return model.StartsWith("gpt-5", StringComparison.Ordinal)
+            || model.StartsWith("o1", StringComparison.Ordinal)
+            || model.StartsWith("o3", StringComparison.Ordinal)
+            || model.StartsWith("o4", StringComparison.Ordinal);
+    }
+}

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -32,6 +32,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         """u8.ToArray());
 
     private readonly ChatClient _chatClient;
+    private readonly string _model;
 
     public OpenAIPdfTableClassificationService(string apiKey, string model)
     {
@@ -45,6 +46,7 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
             throw new ArgumentException("OpenAI model is required.", nameof(model));
         }
 
+        _model = model;
         _chatClient = new ChatClient(model: model, apiKey: apiKey);
     }
 
@@ -60,13 +62,11 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
             new UserChatMessage(BuildPrompt(request)),
         ];
 
-        ChatCompletionOptions options = new()
-        {
-            ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
-                jsonSchemaFormatName: "pdf_table_classification",
-                jsonSchema: ClassificationSchema,
-                jsonSchemaIsStrict: true),
-        };
+        var options = RemediationHelpers.CreateFastChatOptions(_model, maxOutputTokenCount: 500);
+        options.ResponseFormat = ChatResponseFormat.CreateJsonSchemaFormat(
+            jsonSchemaFormatName: "pdf_table_classification",
+            jsonSchema: ClassificationSchema,
+            jsonSchemaIsStrict: true);
 
         ClientResult<ChatCompletion> result =
             await _chatClient.CompleteChatAsync(messages, options, cancellationToken);

--- a/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
+++ b/server.core/Remediate/Table/OpenAIPdfTableClassificationService.cs
@@ -36,7 +36,12 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
     private readonly string _model;
 
     public OpenAIPdfTableClassificationService(string apiKey, string model)
-        : this(model, CreateClient(apiKey))
+        : this(apiKey, model, endpoint: null)
+    {
+    }
+
+    public OpenAIPdfTableClassificationService(string apiKey, string model, string? endpoint)
+        : this(model, CreateClient(apiKey, endpoint))
     {
     }
 
@@ -51,14 +56,14 @@ public sealed class OpenAIPdfTableClassificationService : IPdfTableClassificatio
         _client = client;
     }
 
-    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey, string? endpoint)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        return new OpenAIResponseGenerationClient(apiKey);
+        return new OpenAIResponseGenerationClient(apiKey, endpoint);
     }
 
     public async Task<PdfTableClassificationResult> ClassifyAsync(

--- a/server.core/Remediate/Title/OpenAIPdfTitleService.cs
+++ b/server.core/Remediate/Title/OpenAIPdfTitleService.cs
@@ -12,7 +12,12 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
     private readonly string _model;
 
     public OpenAIPdfTitleService(string apiKey, string model)
-        : this(model, CreateClient(apiKey))
+        : this(apiKey, model, endpoint: null)
+    {
+    }
+
+    public OpenAIPdfTitleService(string apiKey, string model, string? endpoint)
+        : this(model, CreateClient(apiKey, endpoint))
     {
     }
 
@@ -27,14 +32,14 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
         _client = client;
     }
 
-    private static OpenAIResponseGenerationClient CreateClient(string apiKey)
+    private static OpenAIResponseGenerationClient CreateClient(string apiKey, string? endpoint)
     {
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("OpenAI API key is required.", nameof(apiKey));
         }
 
-        return new OpenAIResponseGenerationClient(apiKey);
+        return new OpenAIResponseGenerationClient(apiKey, endpoint);
     }
 
     /// <summary>

--- a/server.core/Remediate/Title/OpenAIPdfTitleService.cs
+++ b/server.core/Remediate/Title/OpenAIPdfTitleService.cs
@@ -7,6 +7,7 @@ namespace server.core.Remediate.Title;
 public sealed class OpenAIPdfTitleService : IPdfTitleService
 {
     private readonly ChatClient _chatClient;
+    private readonly string _model;
 
     public OpenAIPdfTitleService(string apiKey, string model)
     {
@@ -20,6 +21,7 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
             throw new ArgumentException("OpenAI model is required.", nameof(model));
         }
 
+        _model = model;
         _chatClient = new ChatClient(model: model, apiKey: apiKey);
     }
 
@@ -42,7 +44,10 @@ public sealed class OpenAIPdfTitleService : IPdfTitleService
         ];
 
         ClientResult<ChatCompletion> result =
-            await _chatClient.CompleteChatAsync(messages, new ChatCompletionOptions(), cancellationToken);
+            await _chatClient.CompleteChatAsync(
+                messages,
+                RemediationHelpers.CreateFastChatOptions(_model, maxOutputTokenCount: 200),
+                cancellationToken);
 
         return RemediationHelpers.ExtractFirstTextOrEmpty(result.Value);
     }

--- a/server/.env.example
+++ b/server/.env.example
@@ -21,7 +21,7 @@ PDF_SERVICES_CLIENT_SECRET="<adobe_pdf_services_client_secret>"
 
 # openai
 OPENAI_API_KEY="<openai_api_key>"
-# Optional: set for regional API keys, e.g. "https://us.api.openai.com/v1"
+# Optional: override the default endpoint ("https://us.api.openai.com/v1")
 OPENAI_ENDPOINT=""
 
 Auth__ApiKeyHmacSecret="<auth_api_key_hmac_secret>"

--- a/server/.env.example
+++ b/server/.env.example
@@ -21,6 +21,8 @@ PDF_SERVICES_CLIENT_SECRET="<adobe_pdf_services_client_secret>"
 
 # openai
 OPENAI_API_KEY="<openai_api_key>"
+# Optional: set for regional API keys, e.g. "https://us.api.openai.com/v1"
+OPENAI_ENDPOINT=""
 
 Auth__ApiKeyHmacSecret="<auth_api_key_hmac_secret>"
 

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorImageExtractionTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorImageExtractionTests.cs
@@ -144,20 +144,29 @@ public sealed class PdfRemediationProcessorImageExtractionTests
 
     private sealed class CapturingAltTextService : IAltTextService
     {
+        private readonly object _lock = new();
         public List<ImageAltTextRequest> ImageRequests { get; } = new();
         public List<LinkAltTextRequest> LinkRequests { get; } = new();
 
         public Task<string> GetAltTextForImageAsync(ImageAltTextRequest request, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            ImageRequests.Add(request);
+            lock (_lock)
+            {
+                ImageRequests.Add(request);
+            }
+
             return Task.FromResult("fake image alt text");
         }
 
         public Task<string> GetAltTextForLinkAsync(LinkAltTextRequest request, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            LinkRequests.Add(request);
+            lock (_lock)
+            {
+                LinkRequests.Add(request);
+            }
+
             return Task.FromResult("fake link alt text");
         }
 

--- a/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
+++ b/tests/server.tests/Integration/Remediate/PdfRemediationProcessorNoHeaderTableTests.cs
@@ -392,6 +392,53 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
     }
 
     [Fact]
+    public async Task ProcessAsync_NoHeaderTableClassification_UsesConfiguredConcurrency()
+    {
+        var runRoot = Path.Combine(
+            Path.GetTempPath(),
+            "readable-tests",
+            $"no-header-classification-concurrency-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(runRoot);
+
+        try
+        {
+            var inputPdfPath = Path.Combine(runRoot, "input.pdf");
+            CreateVerificationPdfShape(inputPdfPath);
+
+            var outputPdfPath = Path.Combine(runRoot, "output.pdf");
+            var tableClassificationService = new OverlappingPdfTableClassificationService(expectedCalls: 2);
+            var sut = new PdfRemediationProcessor(
+                new ThrowingAltTextService(),
+                new NoopPdfBookmarkService(),
+                NoopPdfPageRasterizer.Instance,
+                tableClassificationService,
+                new StablePdfTitleService(),
+                Options.Create(new PdfRemediationOptions
+                {
+                    OpenAiMaxConcurrency = 2,
+                    NoHeaderTableClassificationTimeoutSeconds = 5,
+                }),
+                NullLogger<PdfRemediationProcessor>.Instance);
+
+            await sut.ProcessAsync(
+                fileId: "no-header-classification-concurrency",
+                inputPdfPath: inputPdfPath,
+                outputPdfPath: outputPdfPath,
+                cancellationToken: CancellationToken.None);
+
+            tableClassificationService.CallCount.Should().Be(2);
+            tableClassificationService.MaxObservedConcurrency.Should().BeGreaterThan(1);
+        }
+        finally
+        {
+            if (Directory.Exists(runRoot))
+            {
+                Directory.Delete(runRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void ListStructElementsByRole_WhenStructTreeContainsCycle_StopsTraversal()
     {
         using var stream = new MemoryStream();
@@ -923,6 +970,73 @@ public sealed class PdfRemediationProcessorNoHeaderTableTests
         {
             CallCount++;
             return new TaskCompletionSource<PdfTableClassificationResult>().Task;
+        }
+    }
+
+    private sealed class OverlappingPdfTableClassificationService : IPdfTableClassificationService
+    {
+        private readonly int _expectedCalls;
+        private readonly TaskCompletionSource _allExpectedCallsStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _callCount;
+        private int _inFlight;
+        private int _maxObservedConcurrency;
+
+        public OverlappingPdfTableClassificationService(int expectedCalls)
+        {
+            _expectedCalls = expectedCalls;
+        }
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public int MaxObservedConcurrency => Volatile.Read(ref _maxObservedConcurrency);
+
+        public async Task<PdfTableClassificationResult> ClassifyAsync(
+            PdfTableClassificationRequest request,
+            CancellationToken cancellationToken)
+        {
+            request.RowCount.Should().BeGreaterThanOrEqualTo(2);
+            request.MaxColumnCount.Should().BeGreaterThanOrEqualTo(2);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var inFlight = Interlocked.Increment(ref _inFlight);
+            UpdateMaxObservedConcurrency(inFlight);
+
+            if (Interlocked.Increment(ref _callCount) >= _expectedCalls)
+            {
+                _allExpectedCallsStarted.TrySetResult();
+            }
+
+            try
+            {
+                await _allExpectedCallsStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+                await Task.Delay(50, cancellationToken);
+                return new PdfTableClassificationResult(
+                    PdfTableKind.NotDataTable,
+                    0.95,
+                    "Synthetic classifier response.");
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _inFlight);
+            }
+        }
+
+        private void UpdateMaxObservedConcurrency(int value)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref _maxObservedConcurrency);
+                if (value <= current)
+                {
+                    return;
+                }
+
+                if (Interlocked.CompareExchange(ref _maxObservedConcurrency, value, current) == current)
+                {
+                    return;
+                }
+            }
         }
     }
 

--- a/tests/server.tests/Remediate/OpenAIRemediationResponseOptionsTests.cs
+++ b/tests/server.tests/Remediate/OpenAIRemediationResponseOptionsTests.cs
@@ -15,6 +15,19 @@ namespace server.tests.Remediate;
 public sealed class OpenAIRemediationResponseOptionsTests
 {
     [Fact]
+    public void ResponseGenerationClient_WhenEndpointProvided_UsesConfiguredEndpoint()
+    {
+        var client = new OpenAIResponseGenerationClient("test-key", "https://us.api.openai.com");
+        var field = typeof(OpenAIResponseGenerationClient).GetField(
+            "_client",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        field.Should().NotBeNull();
+        var responsesClient = field!.GetValue(client).Should().BeOfType<ResponsesClient>().Subject;
+        responsesClient.Endpoint.Should().Be(new Uri("https://us.api.openai.com/v1"));
+    }
+
+    [Fact]
     public async Task PdfTitleService_UsesResponsesOptions()
     {
         var client = new CapturingResponseGenerationClient("Generated title");

--- a/tests/server.tests/Remediate/OpenAIRemediationResponseOptionsTests.cs
+++ b/tests/server.tests/Remediate/OpenAIRemediationResponseOptionsTests.cs
@@ -15,15 +15,20 @@ namespace server.tests.Remediate;
 public sealed class OpenAIRemediationResponseOptionsTests
 {
     [Fact]
+    public void ResponseGenerationClient_WhenEndpointMissing_UsesUsRegionalEndpoint()
+    {
+        var client = new OpenAIResponseGenerationClient("test-key");
+        var responsesClient = GetResponsesClient(client);
+
+        responsesClient.Endpoint.Should().Be(new Uri("https://us.api.openai.com/v1"));
+    }
+
+    [Fact]
     public void ResponseGenerationClient_WhenEndpointProvided_UsesConfiguredEndpoint()
     {
         var client = new OpenAIResponseGenerationClient("test-key", "https://us.api.openai.com");
-        var field = typeof(OpenAIResponseGenerationClient).GetField(
-            "_client",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        var responsesClient = GetResponsesClient(client);
 
-        field.Should().NotBeNull();
-        var responsesClient = field!.GetValue(client).Should().BeOfType<ResponsesClient>().Subject;
         responsesClient.Endpoint.Should().Be(new Uri("https://us.api.openai.com/v1"));
     }
 
@@ -182,6 +187,16 @@ public sealed class OpenAIRemediationResponseOptionsTests
         using var stream = new MemoryStream();
         content.WriteTo(stream, CancellationToken.None);
         return JsonDocument.Parse(Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    private static ResponsesClient GetResponsesClient(OpenAIResponseGenerationClient client)
+    {
+        var field = typeof(OpenAIResponseGenerationClient).GetField(
+            "_client",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        field.Should().NotBeNull();
+        return field!.GetValue(client).Should().BeOfType<ResponsesClient>().Subject;
     }
 
     private sealed class CapturingResponseGenerationClient : IOpenAIResponseGenerationClient

--- a/tests/server.tests/Remediate/PdfRemediationOptionsTests.cs
+++ b/tests/server.tests/Remediate/PdfRemediationOptionsTests.cs
@@ -34,6 +34,12 @@ public sealed class PdfRemediationOptionsTests
     }
 
     [Fact]
+    public void Defaults_OpenAiMaxConcurrency_IsFour()
+    {
+        new PdfRemediationOptions().OpenAiMaxConcurrency.Should().Be(4);
+    }
+
+    [Fact]
     public void IngestOptions_WhenAiCharacterEncodingRepairMissing_DefaultsTrue()
     {
         BuildRemediationOptions().UseAiCharacterEncodingRepair.Should().BeTrue();
@@ -55,6 +61,24 @@ public sealed class PdfRemediationOptionsTests
         {
             ["Ingest:UseAiCharacterEncodingRepair"] = "false",
         }).UseAiCharacterEncodingRepair.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IngestOptions_WhenOpenAiMaxConcurrencyConfigured_BindsValue()
+    {
+        BuildRemediationOptions(new Dictionary<string, string?>
+        {
+            ["Ingest:OpenAiMaxConcurrency"] = "2",
+        }).OpenAiMaxConcurrency.Should().Be(2);
+    }
+
+    [Fact]
+    public void IngestOptions_WhenOpenAiMaxConcurrencyTooHigh_ClampsToEight()
+    {
+        BuildRemediationOptions(new Dictionary<string, string?>
+        {
+            ["INGEST_OPENAI_MAX_CONCURRENCY"] = "99",
+        }).OpenAiMaxConcurrency.Should().Be(8);
     }
 
     private static PdfRemediationOptions BuildRemediationOptions(


### PR DESCRIPTION
## Summary
- add configurable bounded concurrency for OpenAI-backed PDF remediation calls
- parallelize independent alt-text generation and no-header table classification while keeping PDF mutations sequential
- cap OpenAI chat outputs and use low reasoning effort for reasoning-capable configured models

## Testing
- dotnet build
- dotnet test
- real OpenAI smoke test: 10 concurrent link-alt requests returned 10/10 non-empty values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional custom OpenAI endpoint configuration via OPENAI_ENDPOINT
  * Configurable max concurrent OpenAI operations for PDF remediation (default 4, clamped 1–8)
  * Batched, concurrent processing of PDF remediation tasks to improve throughput

* **Bug Fixes**
  * Stronger error handling for link alt-text generation
  * Thread-safety fixes for concurrent alt-text recording

* **Tests**
  * New/updated tests validating concurrency behavior and endpoint handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/readable/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->